### PR TITLE
fix: correct the ui skill's Figma claim and document Grok support

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Unity's official game development plugin. Build, monetize, and operate Unity games
 with guidance grounded in Unity's documented practices.
 
-Available for **Claude Code** and **Codex**.
+Available for **Claude Code**, **Codex**, and **Grok**.
 
 ## Install
 
@@ -27,16 +27,33 @@ codex plugin marketplace add Unity-Technologies/unity-agent-plugin
 codex plugin add unity@unity-agent-plugin
 ```
 
+**Grok**
+
+```bash
+grok plugin install Unity-Technologies/unity-agent-plugin --trust
+```
+
+Grok asks for explicit trust before it installs anything from a repository. This
+plugin ships skills only — no hooks and no MCP servers.
+
 ### Verify it worked
 
-In **Claude Code**, type `/unity:` — the skills appear in the command list. `/plugin`
+Each agent surfaces an installed plugin differently.
+
+**Claude Code** — type `/unity:` and the skills appear in the command list. `/plugin`
 also shows `unity` as installed and enabled.
 
-In **Codex**, run `codex plugin list`:
+**Codex** — run `codex plugin list`:
 
 ```
+PLUGIN                    STATUS              VERSION
 unity@unity-agent-plugin  installed, enabled  0.1.0-beta
 ```
+
+**Grok** — type `/` and the skills appear in the slash menu. Grok uses the plain skill
+name, and switches to the plugin-qualified form (`/unity:ui-uitk`) when another
+installed skill shares the same name. `grok plugin list` shows `unity`, and
+`grok plugin details unity` lists what it provides.
 
 ### Manual install
 
@@ -70,8 +87,8 @@ do something in your Unity project. For example:
 >
 > "Review my ScriptableRendererFeature for Render Graph problems"
 
-Every skill is also available as a command if you prefer to be explicit —
-`/unity:ui-uitk`, `/unity:localization`, and so on.
+In Claude Code and Grok the skills also appear in the slash menu, so you can pick one
+explicitly instead of describing the task.
 
 ## Available skills
 

--- a/skills/ui/SKILL.md
+++ b/skills/ui/SKILL.md
@@ -1,5 +1,5 @@
 ---
-description: Unity UI expert for menus, HUDs, screens, panels, buttons, labels, and all visual interface elements. Handles questions about UI in scenes or prefabs (how many elements, what exists, structure analysis), styling changes (colors, borders, backgrounds, fonts, spacing, rounded corners), layout adjustments, and UI generation. Supports importing design data from Figma projects as part of the UI creation pipeline. Routes to UI Toolkit, uGUI, or IMGUI based on project context.
+description: Unity UI expert for menus, HUDs, screens, panels, buttons, labels, and all visual interface elements. Handles questions about UI in scenes or prefabs (how many elements, what exists, structure analysis), styling changes (colors, borders, backgrounds, fonts, spacing, rounded corners), layout adjustments, and UI generation. Routes to UI Toolkit, uGUI, or IMGUI based on project context.
 ---
 
 Determine the appropriate UI system for the project and route to the correct specialized skill.

--- a/skills/ui/SKILL.md
+++ b/skills/ui/SKILL.md
@@ -88,7 +88,7 @@ Route all types to the appropriate specialized skill based on the UI system.
 - **Understands**, **edits**, and **generates** EditorWindow, inspectors, PropertyDrawers built with OnGUI
 - Not for runtime game UI — for new editor tools, use UI Toolkit unless the project already uses IMGUI exclusively
 
-### Figma design import — not available in this plugin
+### Figma design import — not available here
 
 Importing a Figma design requires Unity's Figma integration service, which only exists
 inside Unity AI Assistant. There is no client-side equivalent, so do not promise it.


### PR DESCRIPTION
Two unrelated-but-small changes: a wording fix in `skills/ui/SKILL.md`, and README updates now that Grok installs this plugin too.

## `skills/ui/SKILL.md` — what the skill claims about Figma

**The description promised something the body retracts.** The `description` claimed `Supports importing design data from Figma projects as part of the UI creation pipeline`, while the body already said Figma import is unavailable. The description is the only text an agent reads when deciding whether a skill applies, so the claim would attract exactly the requests the skill then has to decline. Removed the sentence; the body's explanation stays.

**`not available in this plugin` assumed the reader's install path.** The same skill content is distributed both as part of this plugin and standalone, so "this plugin" is wrong for half of its readers. Changed the heading to `not available here`, which is true either way.

Both fixes are already merged into `Unity-Technologies/skills` (#41), so all copies of this file now differ only by the `name:` key that repo requires.

## README — Grok, and verification per host

Grok Build installs this plugin with no changes to the repo: it reads `.claude-plugin/plugin.json`, and `grok plugin install Unity-Technologies/unity-agent-plugin --trust` pulls in all 22 skills. Added that to the install section, with a note on why Grok asks for `--trust` (it warns before running anything from a repository; this plugin ships skills only, no hooks and no MCP servers).

**Verification is now split per host, because the three agents surface an installed plugin differently.** Claude Code namespaces skills as `/unity:<skill>`. Grok uses the plain skill name and only switches to `/unity:<skill>` when another installed skill shares that name. Codex does not expose skills as commands at all, so `codex plugin list` is the check there — its table header was missing from the sample output and is now included.

The Usage section previously told everyone that every skill is available as `/unity:<skill>`, which is only true in Claude Code. It now names the hosts where the slash menu applies.