### PR TITLE
feat: add the unity-cli skill

### DIFF
--- a/skills/unity-cli/CHANGELOG.md
+++ b/skills/unity-cli/CHANGELOG.md
@@ -1,0 +1,169 @@
+# Changelog — unity-cli skill
+
+All notable changes to the `unity-cli` skill documentation are recorded here. The
+skill documents the published [`unity` CLI](https://public-cdn.cloud.unity3d.com/hub/prod/cli/);
+each entry notes the CLI version the skill was aligned to.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+## [Unreleased] — aligned to CLI `1.0.0-beta.3` (2026-07-24)
+
+Tracks the CLI's `1.0.0-beta.3` release. The CLI's own `[Unreleased]` changes (detached command jobs — `unity command --detach`, `unity job wait/status/cancel` — and live in-terminal progress for `unity command`) are intentionally **not** documented yet: they aren't in the shipped `1.0.0-beta.3` binary.
+
+### Added
+
+- **`unity editors running`** — list running Editor instances and the project each has open (version + PID; cross-platform; an empty list is exit 0).
+- **`unity projects size [project]`** — on-disk footprint by top-level folder (`-a, --all`; `--json` emits raw bytes).
+- **`unity run --command <name>`** — execute a registered `[CliCommand]` Editor command headlessly (arguments after `--` parsed against its `[CliArg]` schema; requires `com.unity.pipeline`).
+- **`unity install --list-components`** — list an editor's available modules and exit (a drop-in alias for `unity modules list <version>`).
+- **`unity bug` non-interactive flags** — `--title`, `--description`, `--steps` (repeatable), `--reproducibility <first-time|sometimes|always>`, `--email`.
+- **`unity shell`** — command-history persistence (↑/↓; secret-bearing flag values masked on disk), tab completion, session context/defaults (`use project|org`, `set format|verbose|banner`, `unset`, `context`), and the `--protocol ndjson` machine/agent mode.
+- Environment variables **`UNITY_NO_CONSENT_PROMPT`** (suppress the first-run consent prompt without recording a choice) and **`UNITY_NO_CRASH_REPORT`** (disable anonymous crash/error reporting).
+- Global **`--json`** shorthand (accepted on every command) in the global-flags table.
+- OSC 9;4 taskbar progress note for `unity install` on interactive terminals.
+- **Driving a running Editor** — three patterns: **persistent headless** (launch the Editor binary in `-batchmode` *without* `-quit`; it stays resident and serves the Pipeline API — drive it with `unity command`/`list` --project-path), **warm/interactive** (`unity open`, which registers with `unity status` as `ready`), and **one-shot CI** (`unity run --command <name>` boots a batch Editor, runs one command, exits). Notes that a bare `unity run` is *not* persistent (batch runs to completion and exits) and — verified — that a batch-mode Editor serves commands but is **not** listed by `unity status`. Closes a gap where the Connected Editors section assumed a running Editor without saying how to get one.
+- **Authoring custom `[CliCommand]` tools** — `[CliCommand]` / `[CliArg]` in the `Unity.Pipeline.Commands` namespace (assembly `Unity.Pipeline`), with `MainThreadRequired` / `RuntimeOnly` as **named properties on `[CliCommand]`** (not separate attributes); worked example, and hot-registration via `unity command recompile` → `unity list`.
+- **Editor-side `eval` / `eval_file`** — noted the runtime-discoverable production path via `unity command eval` / `unity command eval_file`, discovered from the connected Editor.
+- **Live-Editor control surfaced up front** — the skill `description` now advertises controlling a running/connected Editor (create/modify GameObjects, edit scenes, inspect the hierarchy, run C#) so agents pick the skill for scene/GameObject prompts, and a new top-of-skill **"Drive a running Unity Editor"** quickstart shows the minimal `unity status` → `unity command` path ahead of the install steps.
+- **Production live commands + curated command list** — clarified that the whole `unity command <name>` / `com.unity.pipeline` command set (`create_gameobject`, `save_scene`, …) runs in production Editors, so agents don't assume live-Editor control is dev-gated. Added a curated quick-reference of the common built-in scene/GameObject commands, noting `unity command --format json` remains the authoritative catalog.
+- **Scene / GameObject / asset workflow** — a new Common workflows entry makes `unity status` the first move for any scene or object task and, when an Editor is connected, prefers live `unity command` calls over file edits. Adds a strong anti-pattern block against hand-editing `.unity` / `.prefab` / `.asset` YAML while a live Editor is reachable (error-prone fileIDs/GUIDs, invisible until reimport, can silently target the wrong scene), with an explicit "only edit files when no Editor is reachable" fallback.
+- **Recovering from Safe Mode** — a new Connected Editors playbook for the deadlock where a project's C# compile errors force the Editor into Safe Mode, the `com.unity.pipeline` package doesn't load, and `unity command`/`status`/`list`/MCP can't connect. Documents the recovery loop with production-available commands: recognize the connection failure, confirm Safe Mode with `unity pipeline list` (which surfaces the warning, `SafeMode Instances: N detected`, and the "fix compilation errors and restart" hint), read the compile errors from the global `Editor.log` (per-platform paths; disambiguated from `unity logs`, which reads the CLI's own log), fix the C# source, restart Unity, and re-poll until reachable. Cross-linked from the "Drive a running Editor" quickstart and the scene-editing fallback so agents diagnose Safe Mode before falling back to blind file edits. (Addresses community feedback on the 1.0.0-beta.3 rollout thread.)
+
+### Changed
+
+- **`unity upgrade`** — documented Linux AppImage in-place updates and the apt/rpm repositories (GPG-signed rpm); the background "update available" notice is now package-manager-aware (suggests the owning manager's upgrade command) rather than always suppressed on package-managed installs.
+- **`unity analytics`** — expanded the events recorded when opted in (registered command names only, never arguments/paths/project names; editor uninstalls; project open/create; self-upgrade/uninstall; shell/mcp/doctor/bug), noted that `opt-in`/`opt-out` now permanently answer the first-run prompt, and documented the separate anonymous Sentry crash-reporting pathway.
+- **`unity language --set`** accepts BCP-47 / locale / bare-language / bare-region spellings (resolved case-insensitively when unambiguous); catalog shared with the Hub.
+- **`unity projects`** path resolution documented as tolerant of casing, separator direction, and trailing slash (verified against real filesystem identity).
+- Terminal-hardening note extended to Commander usage errors, the `bug` log-archive warning, and `projects add`/`remove` tsv output; noted that an invalid `--proxy` now fails with exit 2; `UNITY_PROJECT_PATH` now honored by `status` and the cloud commands.
+- Refreshed the latest-version note to `1.0.0-beta.3`.
+
+### Security
+
+- Added `SECURITY.md` documenting the skill's powerful-by-design capabilities (local Editor control and C# evaluation, official-CDN install) and the safeguards around them (local-user-context execution, trusted-input-only machine mode, HTTPS official CDN).
+- Clarified that driving a live Editor and running C# happen entirely on the local machine in the user's own account — not remote access — and added a trusted-input warning to `unity shell --protocol ndjson` machine mode.
+- Removed internal development-only command documentation from the public skill; the production Editor-side C# evaluation via `unity command eval` remains documented.
+
+## CLI `1.0.0-beta.2` (2026-07-21)
+
+Tracks the CLI's move to 1.0 versioning (`1.0.0-beta.1` re-baseline) and `1.0.0-beta.2`. The CLI's own `[Unreleased]` changes at the time (e.g. the universal `--json` shorthand) were intentionally not documented in this section — they weren't in the shipped `1.0.0-beta.2` binary (they shipped in `1.0.0-beta.3`, documented above).
+
+### Added
+
+- **`unity shell`** — interactive REPL that boots the CLI once and runs many commands in a warm process (enter commands without the `unity` prefix; `exit` / `quit` / Ctrl-D to leave).
+- **`unity list`** — top-level discovery of a connected Editor's registered tools (name, description, group, parameter schema); introspection-only companion to `unity command`.
+- **`unity diagnose proxy`** — redacted, paste-safe proxy diagnostic report for support (`--json`; a copy is written to the logs dir).
+- **`unity pipeline upgrade`**, **`unity pipeline list-versions`**, and **`unity pipeline install --package-version <v>`** — upgrade the Pipeline package only when the registry is newer, list all published versions, and pin a specific version. Documented that the flag is `--package-version` (not `--version`, which collides with the global `-V, --version`), and the multi-editor selection behavior.
+- **`unity editor module remove` / `unity editors module remove`** — remove installed modules by id (`-m`, repeatable; `-y`, `-a`).
+- **`unity install-modules`** `--reinstall`, `-f` / `--force`, and `--retries <n>` (env `UNITY_INSTALL_RETRIES`); **`--no-elevate`** (env `UNITY_NO_ELEVATE`, Windows) on `install` / `install-modules`.
+- Global **`--log-proxy` / `--no-log-proxy`** (env `UNITY_LOG_PROXY`) — per-request redacted proxy logging.
+- **`unity doctor`** environment health checks (PATH presence, `unity`-binary shadowing, Windows long-path support).
+- Exit code **`143`** (SIGTERM) in the exit-code table.
+
+### Changed
+
+- **`--instance <host:port>` removed** from `unity command`, `unity mcp` — the CLI discovers running Editors itself; target via the project directory or `--project-path`.
+- **Exit codes** — the `cloud` / `auth` commands map an auth failure to `3` and any other operational failure to `6` (previously `1`); `unity build` interrupts exit `130` (SIGINT) / `143` (SIGTERM).
+- **`unity license`** recognizes service-account sessions (`status` reports "Signed in: yes (service account)"); `activate` default/`--personal` fail up front for service accounts, pointing to the unattended modes; `return` now returns serial-activated licenses too, with per-license partial results.
+- **`unity install` / `install-modules`** continue past a failed item and report a per-item result (✓/✗/·), with an `items[]` breakdown in NDJSON.
+- **`unity upgrade`** detects package-manager installs (points at the owning manager instead of self-replacing); the "update available" notice is suppressed there.
+- **`unity analytics`** first-run prompt now requires an explicit `y`/`n` (Enter re-asks); **`unity language`** dropped the regional variants Spanish (Latin America), French (Canada), and Portuguese (Portugal).
+- Refreshed the latest-version note to `1.0.0-beta.2`; noted the move to 1.0 versioning at `1.0.0-beta.1`.
+
+## CLI `0.1.0-beta.8` (2026-06-25)
+
+### Added
+
+- **MCP server** — `unity mcp` (built-in Model Context Protocol stdio server
+  exposing a connected Editor's commands as tools) and
+  `unity mcp configure <client>` (one-step config for 16 AI clients: `claude`,
+  `claude-code`, `cursor`, `vscode`, `vscode-insiders`, `copilot-cli`,
+  `windsurf`, `cline`, `codex`, `kiro`, `trae`, `openclaw`, `antigravity`,
+  `zed`, `continue`, `inspect`; with `--list`, `--local`, `--project-path`,
+  `--yes`, `--dry-run`).
+- **`unity editors upgrade [editor]`** — upgrade an installed editor to the
+  newest f-channel patch in its `major.minor` line, carrying modules over;
+  `--all`, `--replace` (`--remove-old`), `--dry-run` (`--check`), `--no-modules`,
+  `--module`, `--architecture`, `--yes`, `--accept-eula`. Documented the
+  explicit `editors list` subcommand and the new "Upgrade to" column on
+  `editors --installed`.
+- **`unity config update-check`** and the `UNITY_NO_UPDATE_CHECK` env var, plus
+  the background "update available" notice.
+- `unity command screenshot` example (a command forwarded to the Editor).
+
+### Changed
+
+- **`pipeline`, `command`, and `status` promoted from development-only to
+  production.** They now talk to any running Editor, and the Pipeline package
+  (`com.unity.pipeline`) resolves from the **Unity UPM registry** into
+  `Packages/manifest.json` — no internal-network clone or SSH. Moved into a new
+  "Connected Editors" section; dropped `--ssh` / `--install-samples` /
+  `--install-tests` from `pipeline install`; corrected the `command` aliases to
+  `cmd`, `request`.
+- **Auth:** the CLI and the Hub now store sign-in credentials **separately**
+  (previously a shared keyring session).
+- **`unity license list`** now reports a clear error and a non-zero exit when
+  the licensing client is unavailable (previously an empty list).
+- **`unity bug`** collects the same diagnostic system information as the Hub bug
+  reporter (including GPU details).
+- Refreshed the latest-version note to `0.1.0-beta.8`.
+
+### Removed
+
+- **`unity implode`** — removed (use `unity self-uninstall`).
+- Dropped some no-longer-existent command wrappers.
+
+## CLI `0.1.0-beta.7` (2026-06-17)
+
+### Added
+
+- **License management** (`unity license`) — `list`, `status`, `activate`
+  (`--serial` / `--personal` / `--floating` / `--file` / `--generate-request`,
+  mutually exclusive modes), `return`, and `server list|status`. Documented the
+  expected exit codes (`4` when no license / floating server is configured).
+- **`unity hub install`** — bootstrap Unity Hub from the CLI, with
+  `--force`, `--headless` (Windows), `--architecture`, `--hub-version`, and
+  `--skip-signature-check`; documented SHA-512 + code-signature fail-closed
+  verification.
+- **`unity test`** — run EditMode/PlayMode tests via the Editor's built-in test
+  runner, with `--mode`, `--filter`, `--output`, `--editor-version`,
+  `--editor-path`, `--architecture`, `--allow-install`, and `--timeout`
+  (`UNITY_TEST_TIMEOUT`).
+- **`unity editors path <version>`** — print an installed editor's directory
+  (local, offline); clarified its distinction from `editors install-path`.
+- **Projects source control & cloud** — `unity projects clone`,
+  `projects link cloud|vcs`, `projects unlink cloud|vcs` (`--unlink-workspace`),
+  and the full source-control flag set on `projects create` / `link vcs`
+  (`--vcs`, `--git-namespace`, `--git-repo`, `--git-visibility`,
+  `--git-default-branch`, `--git-token` / `--git-token-stdin`,
+  `--no-initial-commit`, `--git-lfs`, `--vcs-region`). Also `projects create
+  --cloud` / `--cloud-project`, and `--template` accepting a `.tgz`/directory.
+- **`unity build` Android signing & export** — `--android-export-type`,
+  `--android-keystore-base64`, `--android-keystore-password`,
+  `--android-key-alias`, `--android-key-alias-password`,
+  `--android-target-sdk-version`, `--android-symbol-type`,
+  `--android-version-code`.
+- New env vars `UNITY_TEST_TIMEOUT` and `UNITY_CLOUD_ORG`; new exit code `4`
+  (precondition not met).
+- Notes on the branded landing-surface header, the CLI's own `cli-log.json`,
+  shared keyring sign-in with Hub, manifest-driven per-module install commands,
+  partial-download self-heal, and terminal output hardening.
+
+### Changed
+
+- **Corrected command availability.** Commands previously presented as generally
+  available were regrouped; several are not part of the published CLI's `--help`.
+  (`pipeline`, `command`, and `status` were later promoted to production in
+  `0.1.0-beta.8`.)
+- `unity templates edit` expanded with its full editable-field flag set and the
+  "at least one field required" rule.
+- Refreshed the latest-version note to `0.1.0-beta.7`.
+
+## CLI `0.1.0-beta.6` — prior baseline
+
+The previous skill revision documented CLI `0.1.0-beta.6`: Unity Cloud
+(`unity cloud …`), proxy support (`unity config proxy`, `--proxy`,
+`--proxy-disable`), analytics consent (`unity analytics …`), custom templates
+(`templates create|edit|delete|location`, `--type`), `unity status`,
+and build versioning (`--versioning-strategy`,
+`--build-version`).

--- a/skills/unity-cli/SECURITY.md
+++ b/skills/unity-cli/SECURITY.md
@@ -1,0 +1,17 @@
+# Security notes — unity-cli skill
+
+This skill documents the official first-party [`unity` CLI](https://public-cdn.cloud.unity3d.com/hub/prod/cli/). A few of its capabilities are powerful by design and are flagged by automated skill scanners. They are intentional, first-party functionality with the safeguards described below.
+
+<!-- skill-security:accept SEC_POWER_CAP, SEC_INSTALL_PIPE -->
+
+## Accepted, by-design capabilities
+
+### Local Editor control and C# evaluation
+
+`unity command`, `unity command eval`, and `unity shell --protocol ndjson` can drive a Unity Editor that is already open on the same machine and run C# through the project's `com.unity.pipeline` package. This executes **entirely on the local machine, in the current user's account, against the user's own Editor** — it is not remote access and grants no privilege the user does not already have at their own terminal. It is the CLI's core value for AI-assisted and automated Editor workflows.
+
+Machine/agent mode (`unity shell --protocol ndjson`) runs the exact commands the caller sends. It validates framing (malformed or unknown requests return an error frame rather than crashing or ending the session), runs every command non-interactively, and returns structured JSON response frames (JSON-serialized, so control characters are escaped for the consuming parser). Callers must feed it **trusted input only** — commands they construct themselves — and never commands assembled from untrusted third-party content, exactly as they would guard any shell.
+
+### Install via the official CDN
+
+The documented install downloads and runs an install script from Unity's official CDN, `public-cdn.cloud.unity3d.com`, **over HTTPS (TLS)**. This pipe-to-shell pattern is a deliberate, industry-standard install convenience for a first-party tool. On Linux the script installs a self-contained binary under `~/.local/bin` and does not modify system package sources. Separately, Unity publishes `.deb`/`.rpm` packages (rpm packages GPG-signed) to its official apt/rpm repositories, so users who prefer package-manager-managed updates can install and update through `apt`/`dnf` instead.

--- a/skills/unity-cli/SKILL.md
+++ b/skills/unity-cli/SKILL.md
@@ -1,0 +1,385 @@
+---
+name: unity-cli
+description: Use when interacting with Unity CLI from the terminal, or to control a running/connected Unity Editor from the command line — create or modify GameObjects, edit scenes and assets, inspect the hierarchy, and run C# in a live Editor instead of hand-editing scene or asset files. Also install, upgrade or uninstall editors, create, list or open projects, manage modules, manage licenses, check auth status, read logs, browse Unity releases, build/test projects, configure the Unity MCP server for AI agents, or run any other Unity CLI operation. For a guided idea-to-running-project flow for a brand-new game, use the new-unity-project skill instead.
+allowed-tools:
+  - Bash
+---
+
+# Unity CLI
+
+## Drive a running Unity Editor (if one is open)
+
+**If a Unity Editor is open on this machine, this CLI can control it live** — create and modify GameObjects, edit scenes and assets, inspect the hierarchy, and run arbitrary C# — through the project's **Pipeline** package (`com.unity.pipeline`). This runs entirely on your local machine, in your own user account, against your own open Editor: it is not remote access and grants no privilege you don't already have at your own terminal. When an Editor is available, drive it instead of hand-editing scene or asset files.
+
+```bash
+unity status                    # confirm a connected Editor (look for state "ready")
+unity command                   # list the commands the Editor exposes
+unity command editor_play       # run one — e.g. enter Play mode
+# Run arbitrary C# — e.g. add a GameObject named "Joe" — when the Editor exposes eval:
+unity command eval 'new UnityEngine.GameObject("Joe");'
+```
+
+Requires the project's `com.unity.pipeline` package (Unity 6.0+) — add it once with `unity pipeline install`. Full details — launching a headless Editor to drive, `unity list` tool discovery, and authoring custom `[CliCommand]` tools — are in [integration-advanced.md](references/integration-advanced.md).
+
+> **Can't connect / commands time out? Check for Safe Mode first.** When a project has C# compile errors, the Editor boots into **Safe Mode**, where the Pipeline package doesn't load — so `unity command` / `status` / `list` can't connect at all. Don't fall back to blind file-editing: run `unity pipeline list` to confirm, then fix the compile errors and restart Unity. Full recovery loop in [integration-advanced.md → Recovering from Safe Mode](references/integration-advanced.md#recovering-from-safe-mode-connection-fails-because-of-compile-errors).
+
+## Step 1: Install the CLI (if not already installed)
+
+First check if the CLI is available:
+
+```bash
+which unity && unity --version
+```
+
+If not found, install it:
+
+**macOS / Linux**
+```bash
+curl -fsSL https://public-cdn.cloud.unity3d.com/hub/prod/cli/install.sh | UNITY_CLI_CHANNEL=beta bash
+```
+
+**Windows (PowerShell)**
+```powershell
+$env:UNITY_CLI_CHANNEL='beta'; irm https://public-cdn.cloud.unity3d.com/hub/prod/cli/install.ps1 | iex
+```
+
+After installing, open a new shell so `unity` is on PATH, then verify:
+
+```bash
+unity --version
+```
+
+If the install script fails or the binary is still not found, tell the user and stop.
+
+## Step 2: Verify it works
+
+```bash
+unity --version
+```
+
+If this fails with a permissions error or crash, the CLI installation may be broken. Suggest re-running the install script.
+
+---
+
+## Global flags
+
+These work on every command:
+
+| Flag | Description |
+|---|---|
+| `--format <fmt>` | Output format: `human` (default), `json`, `tsv`, `ndjson`. Also via `UNITY_FORMAT` env var. |
+| `--json` | Global shorthand for `--format json`, accepted on every command (e.g. `unity status --json`, `unity doctor --json`). `--format` takes precedence when both are supplied. |
+| `--no-banner` | Suppress the branded header — use in scripts |
+| `--non-interactive` | Disable all interactive prompts — use in CI |
+| `--quiet` | Suppress non-essential output |
+| `--verbose` | Print full error details (stack trace + cause chain) on failure. Also via `UNITY_VERBOSE`. |
+| `--proxy <url>` | HTTP/HTTPS/SOCKS/PAC proxy URL for this invocation. Also via `UNITY_PROXY`. Takes precedence over standard `HTTPS_PROXY`/`HTTP_PROXY`/`ALL_PROXY` env vars and the persisted `proxy.json` setting. |
+| `--proxy-disable` | Disable proxy for this invocation, ignoring all sources (env vars, persisted config, system settings). |
+| `--log-proxy` | Log one redacted entry per outbound request (host-only URL, resolved proxy, auth source, status, duration) to `proxy-request.json` — for reproducing proxy issues for support. Also via `UNITY_LOG_PROXY=1` or the persisted `proxyRequestLogging` setting. |
+| `--no-log-proxy` | Opt a single invocation out of proxy request logging when it's enabled globally. |
+
+**Always use `--format json` when you need to parse output programmatically.**
+
+A branded Unity header (logo, wordmark, CLI version) renders on the landing surfaces — bare `unity`, `unity --help` / `-h`, `unity help`, and above the first-run consent prompt. It's shown only on a TTY, prints at most once, and degrades to compact, uncolored text on narrow terminals, without Unicode, or under `NO_COLOR`. Piped output is unaffected. Use `--no-banner` to suppress it in scripts. Bare `unity` prints usage and exits 0.
+
+## Environment variables
+
+All CLI env vars use the `UNITY_` prefix. A CLI flag always overrides the corresponding env var.
+
+| Variable | Mirrors flag | Description |
+|---|---|---|
+| `UNITY_FORMAT` | `--format` | Output format (`human`, `json`, `tsv`, `ndjson`). `HUB_FORMAT` is a deprecated alias. |
+| `UNITY_EDITOR_VERSION` | `--editor-version` | Editor version (e.g. `2023.3.0f1`, `latest`, `lts`). |
+| `UNITY_ARCHITECTURE` | `--architecture` | Chip architecture (`x86_64`, `arm64`). |
+| `UNITY_PROJECT_PATH` | path argument | Project path — used by `open`, and also honored by `status` and the cloud commands. |
+| `UNITY_QUIET` | `--quiet` | Suppress non-essential output. |
+| `UNITY_VERBOSE` | `--verbose` | Show full error details on failure. |
+| `UNITY_NON_INTERACTIVE` | `--non-interactive` | Disable interactive prompts. |
+| `UNITY_NO_BANNER` | `--no-banner` | Suppress the branded banner. |
+| `UNITY_RUN_TIMEOUT` | `--timeout` | Timeout for `unity run` in seconds. |
+| `UNITY_TEST_TIMEOUT` | `--timeout` | Timeout for `unity test` in seconds. |
+| `UNITY_CLOUD_ORG` | `--cloud-org` | Active Unity Cloud organization id or name for a single call. |
+| `UNITY_SERVICE_ACCOUNT_ID` | — | Service account client ID for non-interactive (CI) auth. |
+| `UNITY_SERVICE_ACCOUNT_SECRET` | — | Service account client secret for non-interactive (CI) auth. |
+| `UNITY_PROXY` | `--proxy` | HTTP/HTTPS/SOCKS/PAC proxy URL. Takes precedence over `HTTPS_PROXY`/`HTTP_PROXY`/`ALL_PROXY` and the persisted `proxy.json` setting. |
+| `UNITY_NO_UPDATE_CHECK` | — | Disable the background "update available" check (see `unity config update-check`). |
+| `UNITY_NO_CONSENT_PROMPT` | — | Suppress the one-time first-run analytics consent prompt *without* recording a choice — for wrapper scripts on an interactive terminal that must never absorb the prompt. Analytics stay off until you run `unity analytics opt-in`. Unlike `UNITY_NON_INTERACTIVE`, it changes nothing else about command behavior. |
+| `UNITY_NO_CRASH_REPORT` | — | Disable anonymous crash/error reporting (Sentry) entirely. |
+| `UNITY_LOG_PROXY` | `--log-proxy` | Log one redacted entry per outbound request to `proxy-request.json`. Truthy values: `1`, `true`. |
+| `UNITY_NO_ELEVATE` | `--no-elevate` | Windows: skip the elevated (UAC) install helper for `install` / `install-modules`, so the install service runs unelevated. The Editor's NSIS installer still asks for elevation on demand if Windows requires it for your account — an administrator token always does; a standard user never does. |
+| `UNITY_INSTALL_RETRIES` | `--retries` | Number of times `install-modules` retries a module whose download/validation fails. `0` disables retries. |
+
+**CI service account auth:** Set both `UNITY_SERVICE_ACCOUNT_ID` and `UNITY_SERVICE_ACCOUNT_SECRET` to skip the browser OAuth flow — this keeps the secret out of the process argument list and shell history. These map to the `--client-id` / `--secret-from-stdin` inputs of `unity auth login`, but reading the credentials from the environment isn't a full login: it doesn't run the interactive flow or persist credentials to the keyring.
+
+## Getting help
+
+If a command fails or you're unsure of the available options, append `-h` or `--help` to any command or subcommand:
+
+```bash
+unity --help
+unity install --help
+unity projects --help
+unity projects create --help
+```
+
+This works at every level of the command hierarchy.
+
+## Exit codes
+
+| Code | Meaning |
+|---|---|
+| 0 | Success |
+| 1 | General error |
+| 2 | Bad arguments |
+| 3 | Authentication failure |
+| 4 | Precondition not met (e.g. no license active, floating server not configured) |
+| 6 | Command-specific failure |
+| 130 | Interrupted — Ctrl+C / SIGINT (128 + 2) |
+| 143 | Terminated by SIGTERM (128 + 15) — e.g. `kill` or a CI/runner timeout. Emitted by long-running commands that install a signal handler to clean up first (currently `unity build`, which scrubs the temporary Android keystore). |
+
+The `cloud` and `auth` commands map an authentication failure (expired/missing session, rejected sign-in) to `3`, and any other operational failure (network, server error) to `6` — so scripts can reliably tell "sign in again" apart from a genuine command failure.
+
+---
+
+## Commands
+
+The full per-command reference — syntax, flags, and examples — lives in grouped files under
+[`references/`](references/). **Read the file for the command group you need**; all the global
+flags, environment variables, and exit codes above apply throughout. Every command also supports
+`-h` / `--help` (see [Getting help](#getting-help)).
+
+| Commands | Reference file |
+|---|---|
+| `auth` (login / logout / status), `license` (activate / return / server), `cloud` (org / project) | [auth-license-cloud.md](references/auth-license-cloud.md) |
+| `editors` (list / running / add / default / path / install-path / info / upgrade / module), `install`, `uninstall`, `modules`, `install-modules` | [editors-install.md](references/editors-install.md) |
+| `projects` (list / create / new / clone / open / link / require / upgrade / export / import / pin / size / close), `releases`, `templates` | [projects-templates.md](references/projects-templates.md) |
+| `config` (proxy / update-check), `hub install` | [config-hub.md](references/config-hub.md) |
+| `run`, `test`, `build` | [build-run-test.md](references/build-run-test.md) |
+| `logs`, `doctor`, `env`, `cache`, `analytics`, `changelog`, `language`, `completion`, `bug`, `upgrade`, `self-uninstall`, `diagnose proxy` | [diagnostics-maintenance.md](references/diagnostics-maintenance.md) |
+| `mcp` (+ `configure`), connected editors (`pipeline` / `command` / `status` / `list`), `shell` | [integration-advanced.md](references/integration-advanced.md) |
+
+## Common workflows
+
+### Edit a scene, GameObject, or asset — `unity status` first
+
+**Before editing any scene, GameObject, prefab, or asset, run `unity status` to detect a connected Editor.** If one is reachable, drive it with live commands instead of touching project files — the Editor applies changes to the *actual active scene* and keeps its in-memory state in sync.
+
+```bash
+unity status                       # is an Editor connected? (look for state "ready")
+unity command                      # discover the scene/GameObject commands THIS Editor exposes
+# then drive it with the commands it lists — for example, if your Editor exposes them:
+unity command create_gameobject    # act on the live, active scene
+unity command save_scene           # persist the active scene
+```
+
+Command names are defined by the Editor, so run `unity command` (or `unity list`) to see the exact set — don't assume a name.
+
+> **Never hand-edit `.unity`, `.prefab`, or `.asset` YAML while a live Editor is reachable.** Raw-file edits are:
+> - **error-prone** — fileIDs and GUIDs are assigned by hand and easy to get wrong;
+> - **invisible** to the running Editor until a reimport, so the change silently fails to take effect; and
+> - **prone to hitting the wrong file** — e.g. writing to `SampleScene.unity` while the Editor's active scene is actually `Demo2.unity`, producing valid-looking YAML that changes nothing the user sees.
+
+Only fall back to editing files directly when `unity status` shows **no** reachable Editor — and say so explicitly ("no live Editor detected, editing the file directly").
+
+**One exception worth ruling out first:** if an Editor *is* running for this project but `unity status` / `unity command` won't connect, it may be stuck in **Safe Mode** from a compile error rather than genuinely absent. Run `unity pipeline list` — if it reports Safe Mode, editing the C# source to fix the compile errors (and then restarting Unity) *is* the correct move, not a fallback. See [integration-advanced.md → Recovering from Safe Mode](references/integration-advanced.md#recovering-from-safe-mode-connection-fails-because-of-compile-errors).
+
+### Bootstrap a new project from scratch
+
+> For a **guided** end-to-end experience — concept questions, installing the Editor in the
+> background while you plan, package selection, and monetization handoff — use the
+> **`new-unity-project`** skill. This section is the raw CLI recipe that skill builds on; use it
+> directly when you just want the commands.
+
+Take an idea to a running, version-controlled project using only the CLI. Decide the **target
+platforms first** — they determine which Editor modules you install in step 2. You can add
+modules later (`unity install-modules`), but a project can't build for a platform until that
+platform's module is installed, so it's simplest to decide up front.
+
+```bash
+# 1. Confirm the CLI works and you're signed in and licensed (see references/auth-license-cloud.md).
+unity --version
+unity auth status --format json      # if signed out:      unity auth login
+unity license status --format json   # if none active:      unity license activate
+
+# 2. Pick and install an Editor with the modules your target platforms need.
+#    Default to the latest LTS (most stable, ~2 years of patches). Reach for a Tech-stream
+#    release (--stream tech) only for a feature not yet in LTS; treat --stream beta/alpha as
+#    evaluation-only, never for a project you intend to ship. A deadline argues for LTS.
+#    (lts / latest aliases work wherever a version is accepted.)
+unity releases --stream lts --limit 5 --format json
+unity install lts --module android --module ios --yes --accept-eula   # add --module webgl, etc.
+unity editors --installed --format json                               # confirm it landed
+
+# 3. List the real template ids this Editor offers — don't guess them.
+unity templates list --editor lts --format json
+#    Common ids: com.unity.template.3d, com.unity.template.2d, and a URP template (id varies by version).
+
+# 4. Create the project. The first positional arg is the NAME; --path sets the parent directory.
+#    All options supplied, so it won't prompt; add --non-interactive in CI.
+unity projects create "MyGame" --path ~/UnityProjects \
+  --editor-version lts --template com.unity.template.3d
+```
+
+**Source control — let the user choose.** The CLI publishes the new project to a fresh remote in
+one step for any provider. **Always pass tokens on stdin** (`--git-token-stdin`) so secrets never
+land in shell history or the process list. Pick based on the project — don't default to one:
+
+- **Git — GitHub / GitLab** (`--vcs github` / `--vcs gitlab`). Ubiquitous. For asset-heavy games
+  add **Git LFS** (`--git-lfs`) so large binaries don't bloat history.
+- **Unity Version Control — UVCS** (`--vcs uvcs`). Unity's own VCS, built for large binary game
+  assets: it handles them natively (**no LFS needed**) and supports file locking — often the
+  better fit for art-heavy projects or larger teams. Auth uses your Unity sign-in; `--vcs-region`
+  selects the region.
+
+```bash
+# Git (GitHub) — drop --git-lfs if the game isn't asset-heavy. Add --no-initial-commit if you
+# want to add packages/assets BEFORE the first commit (see the new-unity-project flow).
+unity projects create "MyGame" --path ~/UnityProjects \
+  --editor-version lts --template com.unity.template.3d \
+  --vcs github --git-namespace my-org --git-repo my-game \
+  --git-visibility private --git-default-branch main --git-token-stdin --git-lfs
+
+# Unity Version Control (UVCS) — handles binaries natively, so no LFS:
+unity projects create "MyGame" --path ~/UnityProjects \
+  --editor-version lts --template com.unity.template.3d \
+  --vcs uvcs --git-namespace my-org --git-repo my-game --vcs-region <region>
+```
+
+Feed the token to `--git-token-stdin` from a secret store, never a literal — e.g.
+`… --git-token-stdin <<<"$GIT_TOKEN"` where `$GIT_TOKEN` comes from your CI/secret manager
+(UVCS uses your Unity sign-in, so no token is needed). See
+[references/projects-templates.md](references/projects-templates.md) for the full
+source-control flag set. For a purely local Git repository instead, initialize git with a
+Unity-appropriate ignore so the multi-GB `Library/` and other generated folders are never committed:
+
+```bash
+cd ~/UnityProjects/MyGame
+git init -b main
+# Download (do not pipe to a shell) a maintained Unity .gitignore:
+curl -fsSL https://raw.githubusercontent.com/github/gitignore/main/Unity.gitignore -o .gitignore
+
+# Asset-heavy game? Keep large binaries out of git history with Git LFS:
+git lfs install
+git lfs track "*.psd" "*.fbx" "*.wav" "*.mp3" "*.png"   # adjust to your asset types
+git add .gitattributes
+
+git add -A
+git status                             # sanity-check: Library/ Temp/ obj/ Build/ must NOT be staged
+git commit -m "Initial Unity project: MyGame"
+git ls-files | grep -c '^Library/'     # must print 0
+```
+
+**What the CLI does and doesn't cover.** The CLI handles editor, project, and source control.
+It does **not** manage UPM (Unity Package Manager) packages — to add packages beyond the
+template headlessly, use the **`unity-package-management`** skill (C# PackageManager Client
+API). For monetization/backend, hand off to the dedicated skills: `implement-in-app-purchases`
+(IAP), `levelplay-unity-integration` (ads), or `build-live-game` (accounts, cloud save,
+economy, remote config, leaderboards). Open the project to start working:
+`unity open ~/UnityProjects/MyGame`.
+
+### Find and install a missing editor
+
+```bash
+# 1. Check what's installed
+unity editors --installed --format json
+
+# 2. Browse available LTS versions
+unity releases --lts --limit 5 --format json
+
+# 3. Install
+unity install 6000.0.47f1 --yes --accept-eula
+```
+
+### Open a project with the correct editor
+
+```bash
+# 1. Check the project's required editor version
+unity projects info /path/to/MyProject --format json
+# Look at "editorVersion" in the result
+
+# 2. Confirm that editor is installed
+unity editors --installed --format json
+
+# 3. Open (warns if the editor version is missing)
+unity open /path/to/MyProject
+```
+
+### CI: activate a license, then build
+
+```bash
+# 1. Sign in non-interactively with a service account
+unity auth login --client-id "$UNITY_SERVICE_ACCOUNT_ID" --secret-from-stdin <<<"$UNITY_SERVICE_ACCOUNT_SECRET"
+
+# 2. Activate the entitlement license (or use --serial / --floating)
+unity license activate
+
+# 3. Build
+unity build /path/to/MyProject \
+  --editor-version 6000.0.47f1 \
+  --target StandaloneLinux64 \
+  --execute-method Builder.PerformBuild \
+  --allow-install
+echo "Exit code: $?"
+
+# 4. Return the seat when done (floating/assigned)
+unity license return --yes
+```
+
+### CI: headless build
+
+Prefer the dedicated `unity build` command (handles batch mode, logging, and CI flags):
+
+```bash
+unity build /path/to/MyProject \
+  --editor-version 6000.0.47f1 \
+  --target StandaloneLinux64 \
+  --execute-method Builder.PerformBuild \
+  --allow-install
+echo "Exit code: $?"
+```
+
+Or use `unity run` (batch mode is automatic — never pass `-batchmode`/`-quit`):
+
+```bash
+unity run /path/to/MyProject \
+  --editor-version 6000.0.47f1 \
+  --allow-install \
+  -- -executeMethod Builder.PerformBuild -logFile build.log
+echo "Exit code: $?"
+```
+
+### CI: run tests and publish results
+
+```bash
+unity test /path/to/MyProject \
+  --editor-version 6000.0.47f1 \
+  --mode EditMode \
+  --output ./test-results.xml \
+  --allow-install \
+  --timeout 600
+echo "Exit code: $?"   # 0 = pass, 6 = test failures
+```
+
+### Debug the CLI
+
+```bash
+# Check auth + installed editors + recent errors in one command
+unity doctor --format json
+
+# Follow live logs during an install
+unity logs --follow --level info
+```
+
+---
+
+## Notes
+
+- `--non-interactive` and `--yes` together suppress all prompts — use both in CI.
+- `--format json` always produces machine-readable output; prefer it over parsing human text. Error envelopes are pretty-printed with the same 2-space indent as success envelopes.
+- `unity <version> [path]` is a shorthand for `unity open [path] --editor-version <version>`. Works with `lts`, `latest`, or a full version string like `6000.0.47f1`.
+- The CLI supports kubectl-style plugins: any `unity-<name>` binary on PATH is callable as `unity <name>`.
+- Terminal output is hardened against control-character / escape-sequence injection from server-provided values (project titles, editor versions, module names) — C0 controls and non-SGR escape sequences are stripped from table/list/tree output, and now also from Commander usage errors, the `unity bug` log-archive warning, and `unity projects add`/`remove` machine (tsv) output, while SGR color/style codes are preserved.
+- The CLI reports anonymous crashes and errors via Sentry to help fix bugs (no IP address or hostname; home-directory paths and token-like values scrubbed before send), aligned with the Unity Hub. Opting in to analytics additionally attaches an anonymized machine id; opted-out users stay fully anonymous. Set `UNITY_NO_CRASH_REPORT` to disable reporting entirely.
+- The CLI is currently in **beta** (latest: `1.0.0-beta.3`). It moved to 1.0 versioning at `1.0.0-beta.1`; it's still a beta, so keep `UNITY_CLI_CHANNEL=beta` in the install command until GA ships, after which that part can be dropped.
+- As of `0.1.0-beta.8` the CLI checks in the background for a newer version and prints an unobtrusive "update available" notice (interactive sessions only; never delays a command). Turn it off with `unity config update-check off` or the `UNITY_NO_UPDATE_CHECK` env var.
+- Outbound HTTP from every CLI command honors the resolved proxy (see `unity config proxy`). An invalid `--proxy` value (malformed URL or unsupported scheme) fails with a usage error (exit 2) instead of being silently ignored. Inspect what the CLI actually resolved with `unity env --format json` or `unity doctor --format json` — both surface the active proxy URL, its source, and auth source.

--- a/skills/unity-cli/references/auth-license-cloud.md
+++ b/skills/unity-cli/references/auth-license-cloud.md
@@ -1,0 +1,109 @@
+# Auth, license & cloud — unity-cli command reference
+
+Part of the **`unity-cli`** skill. See that skill's `SKILL.md` for CLI install, global flags,
+environment variables, exit codes, and common workflows. All global flags (`--format json`,
+`--non-interactive`, `--yes`, `--proxy`, …) apply to every command below.
+
+---
+
+### Auth
+
+```bash
+# Check login status
+unity auth status --format json
+
+# Login (opens browser for OAuth)
+unity auth login
+
+# Login with service account credentials (CI — skips browser)
+# Preferred: read secret from stdin to avoid shell-history and process-list exposure
+unity auth login --client-id <id> --secret-from-stdin
+
+# A --client-secret flag also exists, but passing a secret as a
+# command-line argument exposes it in shell history and the process list.
+# Avoid it — use --secret-from-stdin (above) or the
+# UNITY_SERVICE_ACCOUNT_ID / UNITY_SERVICE_ACCOUNT_SECRET env vars instead.
+
+# Login without persisting credentials to the keyring (ephemeral CI)
+unity auth login --client-id <id> --secret-from-stdin --no-store
+
+# Logout (clears both service-account and OAuth credential slots)
+unity auth logout
+
+# Skip the confirmation prompt
+unity auth logout --yes
+```
+
+**Separate sign-in from Hub.** As of `0.1.0-beta.8`, the CLI and the GUI Hub store their sign-in credentials **separately** — signing in to one no longer signs you out of (or overwrites the account of) the other, so each can stay signed in as a different account. (In earlier betas they shared a single keyring session.)
+
+**Service-account credentials via env vars** (`UNITY_SERVICE_ACCOUNT_ID` + `UNITY_SERVICE_ACCOUNT_SECRET`) mint bearer tokens automatically for the duration of the process — no browser round-trip, no keyring write. If only one of the two is set, the CLI prints a warning on stderr instead of silently falling back to the keyring/OAuth identity.
+
+The interactive `unity auth login` flow prints the sign-in URL to the terminal **before** attempting to launch the browser, which unblocks remote/headless sessions (SSH, containers, dev VMs) where `xdg-open` / `open` has no graphical session to attach to. With `--format json`, an `auth_url=…` progress frame is emitted so machine consumers can capture the URL without parsing human text.
+
+`unity auth status` reflects real session state (including an explicit "session expired" message), not optimistic local assumptions. `unity doctor` and `unity cloud status` report the same real session state.
+
+---
+
+### License — list, activate, return
+
+```bash
+# List the Unity licenses active on this machine
+unity license
+unity license list             # explicit form, identical output
+unity license --format json    # machine-readable
+
+# Summary: active license(s) + sign-in state
+unity license status
+
+# Activate a license — choose exactly one mode (default = signed-in subscription)
+unity license activate                              # signed-in user's subscription (entitlement) licenses
+unity license activate --serial SC-…                # serial-based (ULF) activation, no sign-in needed
+unity license activate --personal --accept-eula     # free Unity Personal license (must accept the EULA)
+unity license activate --floating                   # lease a seat from the configured floating server
+unity license activate --file ./Unity_lic.ulf       # offline activation from a .ulf / .xml file
+unity license activate --generate-request ./req.alf # write an offline activation request (air-gapped)
+
+# Return the active licenses — assigned/subscription AND serial-activated (prompts to confirm; --yes skips)
+unity license return
+unity license return --yes
+
+# Floating (network) license server
+unity license server list      # the configured floating license server(s)
+unity license server status    # reachability + available seats
+```
+
+`list` columns: product, license type (`Floating` / `Assigned` / `ULF`), organization, and expiry. `status` prints a one-glance summary — the active license(s) and whether you're signed in — and exits non-zero (`4`) when no license is active, so it works as a scriptable health check. The first licensing command downloads the Unity licensing client on demand; as of `0.1.0-beta.8`, if the client is unavailable `list` reports a clear error and exits non-zero (matching `status`), rather than printing an empty list.
+
+`activate` takes a single mode flag (combining them is a usage error). The default (no flag) and `--personal` activate the signed-in user's entitlements — sign in first with `unity auth login`. `--personal` also requires `--accept-eula` to acknowledge the Unity Personal license terms. `--serial` / `--file` work offline without sign-in. `--floating` requires a configured floating license server (exit `4` if none is set). `--generate-request` writes a `.alf` request for air-gapped activation instead of activating. `return` returns the active licenses, prompting for confirmation first — pass `--yes` to skip (required in non-interactive shells and with `--json`). All honor `--json` / `--format` and exit non-zero on failure (`2` bad usage, `3` sign-in required, `4` floating not configured, `6` licensing-client error).
+
+**Service accounts.** The `license` commands recognize service-account sessions (`UNITY_SERVICE_ACCOUNT_ID` / `UNITY_SERVICE_ACCOUNT_SECRET`, or `unity auth login --client-id`): `unity license status` reports `Signed in: yes (service account)` and includes the auth mode in JSON. Unity's licensing backend does **not** accept service-account tokens for license activation, so with a service-account session the default entitlement mode and `--personal` fail up front — before contacting the licensing client — with guidance toward the unattended options (`--floating`, `--file`, `--generate-request`, or a perpetual `--serial`). `unity license return` lists and returns serial-activated licenses too (not just assigned/subscription seats) — important for CI machines that activate per run — and returns each license individually, so when only some can be freed it reports what succeeded (in text and in the JSON `returned` / `failed` fields) instead of an all-or-nothing failure.
+
+`unity license server list` shows the configured floating license server (from the `licensingServiceBaseUrl` machine setting; a pure settings read, no client download). `unity license server status` contacts that server and reports reachability plus available seats — exit `4` when no server is configured, `6` when configured but unreachable.
+
+---
+
+### Cloud — Unity Cloud organizations and projects
+
+Requires being signed in (`unity auth login`).
+
+```bash
+# Show cloud sign-in state and active organization
+unity cloud status --format json
+
+# Organizations
+unity cloud org list --format json
+unity cloud org current                       # print the active default org id
+unity cloud org set-default <id-or-name>      # set active default org
+unity cloud org clear-default                 # revert to "All Organizations"
+
+# Projects in the active organization
+unity cloud project list --format json
+
+# Override the active organization for a single call
+unity cloud project list --cloud-org <id-or-name>   # also via UNITY_CLOUD_ORG env var
+```
+
+**Exit codes.** The `cloud` and `auth` commands map an authentication failure (expired or missing session, rejected sign-in) to `3`, and any other operational failure (network, server error) to `6` — so scripts can distinguish "sign in again" from a genuine command failure. `unity auth status` / `logout` follow the same convention.
+
+---
+

--- a/skills/unity-cli/references/build-run-test.md
+++ b/skills/unity-cli/references/build-run-test.md
@@ -1,0 +1,205 @@
+# Run, test & build — unity-cli command reference
+
+Part of the **`unity-cli`** skill. See that skill's `SKILL.md` for CLI install, global flags,
+environment variables, exit codes, and common workflows. All global flags (`--format json`,
+`--non-interactive`, `--yes`, `--proxy`, …) apply to every command below.
+
+---
+
+### Run — batch/headless execution
+
+```bash
+# Run a Unity project headless (batch mode is automatic — do NOT pass -batchmode/-quit)
+unity run /path/to/MyProject -- -executeMethod Builder.Build
+
+# Override editor version
+unity run /path/to/MyProject --editor-version 6000.0.47f1 -- -nographics -logFile out.log
+
+# Install editor automatically if missing
+unity run /path/to/MyProject --allow-install -- -executeMethod Builder.Build
+
+# Kill the Unity process after 300 seconds (useful in CI to prevent hangs)
+unity run /path/to/MyProject --timeout 300 -- -executeMethod Builder.Build
+# Equivalent via env var:
+UNITY_RUN_TIMEOUT=300 unity run /path/to/MyProject -- -executeMethod Builder.Build
+```
+
+`unity run` always launches the editor in batch mode and forwards the args after `--` to the Unity executable, then returns the editor's exit code.
+
+**Reserved flags — do NOT pass these after `--`.** The command manages `-batchmode`, `-quit`, and `-projectPath` itself, and deliberately never passes `-useHub`/`-hubIPC` (the CLI runs no Hub IPC server, so those flags would make the editor launch the Unity Hub). Passing any of the five fails fast (before launch) with exit code 6:
+
+```
+Error: Forwarded argument '-batchmode' conflicts with a reserved Unity flag managed by this command. Remove it from the args after `--`.
+```
+
+Flags like `-nographics`, `-logFile <path>`, and `-executeMethod <Class.Method>` are not reserved and are forwarded normally.
+
+Reserved-flag matching is spelling-insensitive: Unity accepts `-projectPath`, `--projectPath` and `-projectPath=<value>` interchangeably, so all three spellings are rejected (case-insensitively). This applies to every command that forwards user args — `unity run`, `unity test`, `unity build --args`, and `unity open --args`.
+
+When `--timeout <seconds>` is set, the process receives SIGTERM at the deadline; if still alive after 2 s it receives SIGKILL. The command exits with code 6 (EXIT_COMMAND_FAILURE) on timeout.
+
+#### run --command — execute a registered Editor command headlessly
+
+`unity run --command <name>` runs a registered `[CliCommand]` Editor command in a single invocation: the CLI starts the Editor in batch mode, waits for the project's Pipeline server, runs the command with the arguments after `--` parsed against the command's `[CliArg]` schema (no hand-written `Environment.GetCommandLineArgs()` parsing), prints the return value, and shuts the Editor down. A running Editor with the project already open is reused (and left running) instead of spawning a second one. Requires the `com.unity.pipeline` package (`unity pipeline install` — see [integration-advanced.md](integration-advanced.md)).
+
+```bash
+# Run a registered command; arguments after -- are parsed against its [CliArg] schema
+unity run /path/to/MyProject --command my_command -- --count 3 --label demo
+
+# JSON result envelope (data carries the return value); bound the wait
+unity run /path/to/MyProject --command my_command --format json --timeout 120
+```
+
+**Worked example.** Given this command in the project (authoring details in [integration-advanced.md](integration-advanced.md)):
+
+```csharp
+public static class MyPipelineCommands
+{
+    [CliCommand("greet", "Log a greeting and return its length")]
+    public static int Greet(
+        [CliArg("name", "Who to greet", Required = true)] string name)
+    {
+        Debug.Log($"Hello, {name}!");
+        return name.Length;
+    }
+}
+```
+
+`unity run . --command greet -- --name Ada` prints the return value (`name.Length` → `3`) last on stdout, while the Editor log — including the `Hello, Ada!` from `Debug.Log` — streams to stderr:
+
+```text
+Starting Unity 6000.0.47f1 (Apple Silicon)...
+Waiting for the Pipeline server to start...
+Executing "greet" on the Editor...
+Command "greet" completed.
+3
+```
+
+With `--format json`, stdout carries a single result envelope instead — `data.result` is the return value, `data.parameters` the parsed args, and `data.reusedRunningEditor` tells you whether an already-open Editor was used:
+
+```json
+{
+  "success": true,
+  "command": "run",
+  "data": {
+    "projectPath": "/path/to/MyProject",
+    "command": "greet",
+    "parameters": {
+      "name": "Ada"
+    },
+    "result": 3,
+    "reusedRunningEditor": false,
+    "success": true
+  },
+  "errors": [],
+  "warnings": []
+}
+```
+
+The Editor log — including `Debug.Log` output — streams to stderr, and a failed command exits non-zero. Unlike a bare `unity run` (which forwards args to the Unity executable), `--command` targets a Pipeline command by name; use `unity command` / `unity list` in [integration-advanced.md](integration-advanced.md) to discover what a connected Editor exposes.
+
+---
+
+### Test — run EditMode/PlayMode tests
+
+```bash
+# Run tests and write an NUnit XML report (omitting --mode runs the editor's default platform)
+unity test /path/to/MyProject
+
+# Run a specific platform (--mode is case-insensitive: EditMode/editmode both work)
+unity test /path/to/MyProject --mode EditMode
+unity test /path/to/MyProject --mode PlayMode --output ./results/play.xml
+
+# Run only tests whose names match a filter
+unity test /path/to/MyProject --filter "MyNamespace.MyTests"
+
+# Pin the editor version, installing it if missing; cap the run at 600 s
+unity test /path/to/MyProject --editor-version 6000.0.47f1 --allow-install --timeout 600
+# Equivalent via env var:
+UNITY_TEST_TIMEOUT=600 unity test /path/to/MyProject
+
+# Forward extra editor args after -- (reserved test flags are rejected)
+unity test /path/to/MyProject -- -nographics
+```
+
+`unity test` launches the editor's built-in test runner in batch mode (`-runTests -testPlatform <mode> -testResults <path> -testFilter <pattern>`), waits for it to finish, and writes the report to `--output` (default `test-results.xml`). It exits 0 when the run succeeds and 6 (EXIT_COMMAND_FAILURE) when the editor exits non-zero — i.e. reports test failures or fails to run. It runs the tests **directly via the editor command line** — no pipeline package or server is involved. `--mode` is optional; when omitted, `-testPlatform` is not passed and the editor runs its default platform.
+
+It deliberately does **not** pass `-quit`: `-runTests` quits the editor itself once results are written, so forcing `-quit` would terminate it before the report exists. Anything after `--` is forwarded to the editor verbatim, except reserved flags (`-projectPath`, `-batchmode`, `-runTests`, `-testPlatform`, `-testResults`, `-testFilter`, `-quit`, `-useHub`, `-hubIPC`), which are rejected — the first seven are managed by the command; `-useHub`/`-hubIPC` are deliberately never passed (the CLI runs no Hub IPC server).
+
+Options: `--mode EditMode|PlayMode`, `--filter <pattern>`, `--output <path>`, `--editor-version <version>` (env `UNITY_EDITOR_VERSION`), `-e, --editor-path <path>`, `-a, --architecture <arch>`, `--allow-install`, `--timeout <seconds>` (env `UNITY_TEST_TIMEOUT`).
+
+---
+
+### Build
+
+The first-class build workflow. Rule of thumb vs `unity run`: building a player → `unity build`; anything else headless → `unity run`.
+
+Pick one build strategy: a Unity 6+ Build Profile (`--profile`), a built-in desktop player build (`--target` with a desktop target, `--output-path` required), or a custom `--execute-method` (your method is responsible for the actual build, including honoring `--output-path`). Non-desktop targets need `--profile` or `--execute-method`.
+
+The build log is always written to the log file **and** streamed to stdout at the same time; pass `--no-tail` to write the file only (the tail is also suppressed by `--quiet` and `--format ndjson`).
+
+```bash
+# Build with a custom build method
+unity build /path/to/MyProject \
+  --target StandaloneOSX \
+  --execute-method Builder.PerformBuild \
+  --output-path ./build/output
+
+# Build with a Unity 6+ build profile
+unity build /path/to/MyProject --profile "Windows Release" --output-path ./Build/MyGame.exe
+
+# Common build targets: StandaloneOSX, StandaloneWindows64, StandaloneLinux64, Android, iOS, WebGL
+```
+
+**Options:**
+
+| Flag | Description |
+|---|---|
+| `--target <target>` | Build target (required unless `--profile` is used). |
+| `--execute-method <method>` | Static C# method to invoke, e.g. `Builder.PerformBuild`. Optional: without it, the CLI uses Unity's built-in build. |
+| `--profile <profile>` | Build profile: a `.asset` path or a profile name in `Assets/Settings/Build Profiles` (Unity 6+; the profile defines the target). |
+| `--build-target-group <group>` | Forwarded to Unity as `-buildTargetGroup`. |
+| `-o, --output-path <path>` | Output path. With `--execute-method`, passed as `-buildOutput` (your method must honor it); otherwise the built-in build's destination (required). |
+| `-l, --log-file <path>` | Log file path. Default: `<project>/Logs/build-<target>-<timestamp>.log`. Streamed to stdout by default (see `--no-tail`). |
+| `--editor-version <version>` | Override editor version (default: from `ProjectVersion.txt`). |
+| `-e, --editor-path <path>` | Use a specific editor binary. |
+| `-a, --architecture <arch>` | Editor architecture (`x86_64` or `arm64`). |
+| `--args <string>` | Extra arguments passed to Unity (shell-split). |
+| `--no-tail` | Do not stream the log to stdout in real time. |
+| `--allow-install` | Install the project's editor version if missing. |
+| `--versioning-strategy <strategy>` | `semantic`, `tag`, `custom`, or `none` (default: `none`). |
+| `--build-version <version>` | Explicit version string; only used with `--versioning-strategy custom`. |
+| `--allow-dirty-build` | Skip the uncommitted-changes guard (default: false). |
+
+**Android signing & export** (applied to Android targets only):
+
+| Flag | Description |
+|---|---|
+| `--android-export-type <type>` | `apk`, `aab`, or `android-studio-project`. |
+| `--android-keystore-base64 <b64>` | Keystore file, base64-encoded. |
+| `--android-keystore-password <pass>` | Keystore password. |
+| `--android-key-alias <alias>` | Key alias within the keystore. |
+| `--android-key-alias-password <pass>` | Key alias password. |
+| `--android-target-sdk-version <N>` | Target SDK version. |
+| `--android-symbol-type <type>` | `none`, `public`, or `debugging`. |
+| `--android-version-code <N>` | Android version code. |
+
+Keystore flags are validated together. Secrets passed as command-line flags surface in the process list and can be echoed into CI logs. Supply `--android-keystore-base64`, `--android-keystore-password`, and `--android-key-alias-password` from CI secret environment variables (e.g. `--android-keystore-password "$KEYSTORE_PASSWORD"`), never as inline literals, and source those variables from a dedicated CI secret store. Note that sourcing from an env var only avoids hard-coding the literal — the expanded value still appears in `argv`, so also mask it in CI log output.
+
+**Versioning** — `semantic` and `tag` derive the version from git tags/history; `custom` requires an explicit `--build-version`; a dirty working tree is rejected unless `--allow-dirty-build` is passed.
+
+**Interrupt exit codes** — interrupting `unity build` exits with the conventional signal code (`130` for Ctrl-C / SIGINT, `143` for SIGTERM) rather than a generic `1`, so callers and CI can tell an aborted build apart from a failed one. The temporary Android keystore is scrubbed before exit.
+
+```bash
+# With --format json, stdout includes newline-delimited JSON progress frames before the final envelope:
+unity build /path/to/MyProject --target StandaloneOSX --execute-method Builder.Build --format json
+# Output (each line is a JSON object):
+# {"type":"progress","command":"build","message":"Resolving project..."}
+# {"type":"progress","command":"build","message":"Resolving editor..."}
+# {"type":"progress","command":"build","message":"Starting Unity..."}
+# {"type":"progress","command":"build","message":"Unity exited (code 0)"}
+# { "success": true, "command": "build", "data": { "target": "...", "logFile": "..." } }
+```
+
+---
+

--- a/skills/unity-cli/references/config-hub.md
+++ b/skills/unity-cli/references/config-hub.md
@@ -1,0 +1,103 @@
+# Config & Hub — unity-cli command reference
+
+Part of the **`unity-cli`** skill. See that skill's `SKILL.md` for CLI install, global flags,
+environment variables, exit codes, and common workflows. All global flags (`--format json`,
+`--non-interactive`, `--yes`, `--proxy`, …) apply to every command below.
+
+---
+
+### Config — persisted CLI configuration
+
+The `config` command group manages settings that persist across invocations.
+
+#### config proxy
+
+View or change the configured HTTP/HTTPS/SOCKS/PAC proxy. The persisted value is read by every CLI command that issues outbound HTTP (releases, install, auth, telemetry, etc.).
+
+```bash
+# Show the effective proxy configuration (resolution source + auth source)
+unity config proxy
+unity config proxy --json
+
+# Persist a proxy URL
+unity config proxy http://proxy.example.com:8080
+
+# Embedded userinfo (user:password@host) is supported and redacted in echo
+# output, but prefer leaving credentials out of the URL — the CLI looks them
+# up in the OS keyring instead (see Resolution priority below).
+
+# Persist with bypass list (hosts that should NOT go through the proxy)
+unity config proxy http://proxy.example.com:8080 --bypass "localhost,127.0.0.1,*.internal"
+
+# SOCKS / PAC variants
+unity config proxy socks5://proxy.example.com:1080
+unity config proxy pac+http://wpad.example.com/proxy.pac
+unity config proxy pac+file:///etc/proxy.pac
+
+# Clear the persisted proxy
+unity config proxy --unset
+```
+
+**Supported schemes:** `http://`, `https://`, `socks://`, `socks4://`, `socks4a://`, `socks5://`, `socks5h://`, `pac+http://`, `pac+https://`, `pac+file://`.
+
+**Resolution priority** (highest → lowest):
+1. `--proxy <url>` global flag (one-shot override for the current invocation)
+2. `UNITY_PROXY` env var
+3. Standard env vars: `HTTPS_PROXY`, `HTTP_PROXY`, `ALL_PROXY`, `NO_PROXY`
+4. Persisted `proxy.json` (`unity config proxy <url>`)
+5. System proxy settings (where supported)
+
+Credentials missing from the URL are looked up in the OS keyring (shared with the GUI Hub); Kerberos/SPNEGO-authenticated proxies are supported. `--proxy-disable` short-circuits all of the above for the current invocation, which is the recommended way to diagnose a misconfigured proxy without clearing it.
+
+#### config update-check
+
+New in `0.1.0-beta.8`. Enable or disable the background check for a newer CLI version (the unobtrusive "update available" notice; interactive sessions only, never delays a command). Equivalent to the `UNITY_NO_UPDATE_CHECK` env var.
+
+```bash
+unity config update-check          # show the current setting
+unity config update-check off      # disable
+unity config update-check on       # enable
+unity config update-check --json
+```
+
+---
+
+### Hub — install the Unity Hub application
+
+Bootstrap Unity Hub on a clean machine from the command line.
+
+```bash
+# Install the latest stable Hub for the current OS + architecture
+unity hub install
+
+# Install a specific Hub version
+unity hub install --hub-version 3.17.0
+
+# Force reinstall even when Hub is already detected
+unity hub install --force
+
+# Run the installer silently (Windows only)
+unity hub install --headless
+
+# Override architecture (e.g. x64 Hub on Apple Silicon via Rosetta)
+unity hub install --architecture x64
+
+# Skip the installer code-signature check (unsigned/local builds — not recommended)
+unity hub install --skip-signature-check
+```
+
+Options: `-f` / `--force`, `--headless` (silent installer, Windows only), `-a` / `--architecture x64|arm64` (env `UNITY_ARCHITECTURE`), `--hub-version <version>` (default latest), `--skip-signature-check`.
+
+**Integrity & signature verification** — every download is checked against the SHA-512 from the HTTPS manifest, then the installer's **code signature** is verified before it runs with elevation: on macOS via `codesign` (signer `Developer ID Application: Unity Technologies`), on Windows via Authenticode (signer subject `Unity Technologies`), checked *before* the UAC prompt. Verification is **fail-closed** — if it fails or the verifier is unavailable, the command aborts with exit 6 and does not run the installer. Linux `.AppImage` has no standard verifier, so it is SHA-512-only. Pass `--skip-signature-check` to bypass (prints a warning; not recommended).
+
+**`--hub-version` behaviour** — fetches the version-specific manifest from the CDN; if that version does not exist, the command exits with code 6 (no fallback to latest).
+
+```bash
+# JSON output
+unity hub install --format json
+```
+
+Emits `{ "success": true, "command": "hub install", "data": { "version": "3.x.x", "installed": true } }` on success, or an `{ "alreadyInstalled": true, "installedPath": "…" }` payload when Hub was already present.
+
+---
+

--- a/skills/unity-cli/references/diagnostics-maintenance.md
+++ b/skills/unity-cli/references/diagnostics-maintenance.md
@@ -1,0 +1,244 @@
+# Diagnostics & maintenance — unity-cli command reference
+
+Part of the **`unity-cli`** skill. See that skill's `SKILL.md` for CLI install, global flags,
+environment variables, exit codes, and common workflows. All global flags (`--format json`,
+`--non-interactive`, `--yes`, `--proxy`, …) apply to every command below.
+
+---
+
+### Logs — application logs
+
+```bash
+# Show last 20 log lines (default)
+unity logs
+
+# Show last 50 lines
+unity logs --tail 50
+
+# Follow in real-time (like tail -f)
+unity logs --follow
+
+# Filter by level
+unity logs --level error
+unity logs --level warn
+
+# Available levels: trace, debug, info, warn, error, fatal
+```
+
+The CLI writes its own `cli-log.json` (separate from the Hub's `info-log.json`) and records its version on every start. `unity logs`, `unity bug`, and `unity doctor` read the CLI's own log.
+
+> **Not the Unity Editor log.** `unity logs` shows the *CLI's* activity, **not** the Editor's
+> `Editor.log`. To read Editor-side output — for example the compile errors that force an Editor into
+> Safe Mode and block the Pipeline connection — read `Editor.log` directly (see
+> [integration-advanced.md → Recovering from Safe Mode](integration-advanced.md#recovering-from-safe-mode-connection-fails-because-of-compile-errors) for its per-platform path and the full recovery loop).
+
+---
+
+### Doctor — system diagnostics
+
+```bash
+# Full system report
+unity doctor --format json
+
+# Includes: platform info, auth status, installed editors, recent log lines, resolved proxy
+unity doctor --tail 50
+```
+
+`unity doctor` reports real session state (matching `unity auth status`) and surfaces the resolved proxy URL, its source, and auth source. It also runs environment health checks and reports pass/warn per check (in every output format): whether the `unity` binary's directory is actually on `PATH` (the top post-install pitfall on Windows, where a new terminal is needed), whether multiple `unity` binaries shadow each other on `PATH`, and whether Windows long-path support is enabled.
+
+---
+
+### Diagnose proxy — proxy diagnostic report
+
+```bash
+# Print a redacted, paste-safe proxy diagnostic report for support
+unity diagnose proxy
+
+# Machine-readable
+unity diagnose proxy --json
+```
+
+Reports the resolved proxy and where it came from, PAC configuration, CA bundle, and credential-store and Kerberos checks — redacted so it's safe to paste into a support ticket. A copy is also written to the logs directory. For per-request proxy logging over the course of a repro, use the global `--log-proxy` flag (or `UNITY_LOG_PROXY=1`), which writes one redacted entry per outbound request to `proxy-request.json`.
+
+---
+
+### Environment
+
+```bash
+# Show environment paths
+unity env --format json
+
+# Returns: user data path, editor install path, download cache path, config path, CLI version, resolved proxy
+```
+
+---
+
+### Cache
+
+```bash
+# Show cache location and size
+unity cache info --format json
+
+# Clear download cache
+unity cache clean --yes
+```
+
+---
+
+### Analytics — usage/telemetry consent
+
+The CLI defaults to **opt-out**. On the first interactive run a prompt is shown once before any data is collected; it now requires an explicit `y` or `n` — pressing Enter alone re-asks instead of silently recording the opt-out default, so an accidental keystroke can't lock in an answer. Ctrl-C skips the prompt and keeps the opt-out default. Non-interactive, CI, piped, and `--quiet` contexts silently keep the opt-out default.
+
+Running `unity analytics opt-in` or `opt-out` permanently answers the first-run prompt, so a choice recorded from a script (where the prompt never appears) isn't asked again on the next interactive run. To suppress the prompt *without* recording a choice — for a wrapper script on an interactive terminal that must never absorb it — set `UNITY_NO_CONSENT_PROMPT` (analytics stay off until you explicitly opt in).
+
+```bash
+# Show current consent status
+unity analytics status
+unity analytics status --format json
+
+# Opt in to anonymous usage data collection
+unity analytics opt-in
+
+# Opt out (the default)
+unity analytics opt-out
+```
+
+Consent is stored in the shared Hub privacy preferences, so opting out in the CLI also opts out in Hub, and vice versa. When opted **in**, the CLI records which commands run (registered command names only — never your arguments, paths, or project names), editor uninstalls, project open/create (editor version and template id only), CLI self-upgrade/uninstall outcomes, `unity shell` and `unity mcp` session usage, and `unity doctor` / `unity bug` results. When opted out (the default), no events are sent.
+
+Separately from analytics, the CLI reports **anonymous crashes and errors** via Sentry to help fix bugs (no IP address or hostname; home-directory paths and token-like values scrubbed before send), aligned with the Unity Hub. Opting in to analytics additionally attaches an anonymized machine id so crash-free-user rates can be computed; opted-out users stay fully anonymous. Set `UNITY_NO_CRASH_REPORT` to disable crash reporting entirely.
+
+---
+
+### Changelog
+
+Show the embedded release notes for the currently installed CLI version:
+
+```bash
+unity changelog
+unity changelog --format json
+```
+
+---
+
+### Language
+
+```bash
+# Show current language and available options
+unity language
+
+# Set language by code
+unity language --set en
+unity language --set ja
+unity language --set zh-hans
+
+# Alias
+unity lang --set ko
+```
+
+On a TTY with no flags, shows an interactive selection prompt. `--set` accepts common spellings of a language code — BCP-47 (`ja-JP`), locale (`ja_JP`), a bare language (`ja`), or a bare region (`jp`) — and resolves them case-insensitively when the match is unambiguous (`zh` still asks you to pick `zh_cn` or `zh_tw`). Display names and ordering come from the shared Hub language catalog. The regional variants Spanish (Latin America), French (Canada), and Portuguese (Portugal) are no longer offered; Spanish, French, and Portuguese (Brazil) remain.
+
+---
+
+### Completion — shell tab completion
+
+Generate and install shell completion scripts:
+
+```bash
+# Supported shells: bash, zsh, fish, powershell
+unity completion bash
+unity completion zsh
+unity completion fish
+unity completion powershell
+```
+
+---
+
+### Bug — report a bug
+
+Interactive bug reporter that collects system info and recent logs, then submits to Unity:
+
+```bash
+# Interactive — prompts for each field
+unity bug
+
+# Non-interactive — supply the report through flags (works from scripts, CI, piped shells)
+unity bug \
+  --title "Editor crashes on project open" \
+  --description "Opening MyGame hard-crashes the editor." \
+  --steps "Open the CLI" --steps "Run unity open MyGame" --steps "Editor window closes" \
+  --reproducibility always \
+  --email you@example.com \
+  --attachments ./crash.log ./notes.txt \
+  --share-project .
+```
+
+Prompts for title, description, email, and reproducibility level. As of `0.1.0-beta.8` it collects the same diagnostic system information as the Unity Hub bug reporter (including GPU details).
+
+The report can also be supplied entirely through flags — `--title`, `--description`, `--steps` (repeatable, one line per value), `--reproducibility <first-time|sometimes|always>`, and `--email` (defaults to your Unity account email when signed in; otherwise required). On a terminal, any flags you pass skip their prompts and the remaining fields still ask; a non-interactive run submits without prompting. A non-interactive run with missing or invalid fields fails fast with a usage error (exit 2) listing the exact flags to add.
+
+Use `--attachments <paths...>` (repeatable) to attach extra files — for example a crash log or a zipped copy of a subset of assets. Each path must be an existing, readable file; a folder is rejected (zip it yourself first), and a missing or unreadable path fails fast with a usage error (exit 2) naming the offending path.
+
+Use `--share-project <path>` (use `.` for the current directory) to attach a copy of the Unity project the bug is about — the same stripped-project packaging the Editor's bug reporter uses. It sends the source folders plus a slimmed `Library`, excluding the regenerable caches and build output (`Library` caches, `Temp`, `Build`, `Logs`, VCS/IDE metadata, `MemoryCaptures`, `CrashReports`), so you don't have to zip the project yourself. A path that isn't a Unity project fails fast with exit 2. The archive is streamed from disk during upload, so there's no size limit — even a multi-gigabyte project copy uploads without being buffered in memory.
+
+Interactively, when you don't pass `--attachments` or `--share-project`, the reporter asks whether to attach files and whether to include a project copy. Everything — attachments and the project copy — is bundled into the same archive as the auto-collected logs.
+
+---
+
+### Upgrade — update the CLI itself
+
+```bash
+# Check for available updates
+unity upgrade --check --format json
+
+# Show changelog for the new version
+unity upgrade --changelog
+
+# Upgrade (interactive confirmation)
+unity upgrade
+
+# Upgrade without prompts
+unity upgrade --yes
+
+# Install a specific version
+unity upgrade --target 0.2.0
+
+# Select update channel (stable or beta)
+unity upgrade --channel beta
+
+# Dry-run: show what would change
+unity upgrade --dry-run
+
+# Rollback to previous version
+unity upgrade --rollback
+```
+
+`unity upgrade` detects how the CLI was installed and upgrades accordingly:
+
+- **`curl | sh` install** — keeps upgrading itself in place.
+- **Linux AppImage** — updates in place: downloads the new `.AppImage` artifact, verifies its checksum against the release manifest, and atomically replaces the AppImage you launched (`--rollback` restores the previous one). The embedded zsync update info is preserved, so external updaters (AppImageUpdate, Gear Lever) keep working.
+- **Package-manager install** — points you at the owning manager instead of replacing the binary. The `.deb` and `.rpm` packages are published to Unity's apt and rpm repositories on every beta and GA release (rpm packages are GPG-signed), so a package-managed install stays current through the system package manager: `sudo apt update && sudo apt upgrade unity-cli` on Debian/Ubuntu, `sudo dnf upgrade unity-cli` on Fedora/RHEL.
+
+`--check`, `--changelog`, and `--dry-run` work everywhere. The background "update available" notice is package-manager-aware: when the release manifest says your install's package manager already carries the new version, the notice suggests that manager's exact upgrade command instead of `unity upgrade`; installs whose manager doesn't carry the release yet stay quiet.
+
+---
+
+### Self-uninstall — remove the CLI
+
+```bash
+# Uninstall the CLI (interactive confirmation)
+unity self-uninstall
+
+# Uninstall without prompts
+unity self-uninstall --yes
+
+# Also remove config and data files
+unity self-uninstall --purge --yes
+
+# Dry-run: show what would be removed
+unity self-uninstall --dry-run
+```
+
+> **`unity implode` was removed** in `0.1.0-beta.8` (it was previously a deprecated alias). Use `unity self-uninstall`.
+
+---
+

--- a/skills/unity-cli/references/editors-install.md
+++ b/skills/unity-cli/references/editors-install.md
@@ -1,0 +1,290 @@
+# Editors, install & modules — unity-cli command reference
+
+Part of the **`unity-cli`** skill. See that skill's `SKILL.md` for CLI install, global flags,
+environment variables, exit codes, and common workflows. All global flags (`--format json`,
+`--non-interactive`, `--yes`, `--proxy`, …) apply to every command below.
+
+---
+
+### Editors — list, install, uninstall
+
+```bash
+# List all editors (installed + available releases)
+# Short alias: unity e. The bare `unity editors` is shorthand for the explicit `unity editors list` (matches projects/templates/modules)
+unity editors list --format json
+
+# List only installed editors
+# As of 0.1.0-beta.8 the --installed table includes an "Upgrade to" column flagging editors with a newer patch in their line
+unity editors --installed --format json
+
+# List only available releases
+unity editors --releases --format json
+
+# Filter by architecture
+unity editors --installed --architecture arm64 --format json
+
+# Show detailed module info
+unity editors --verbose
+
+# Watch mode — live-updates as editors are installed or removed
+unity editors --watch
+unity editors --installed --watch
+```
+
+`unity editors` honors `--format tsv` and `--format ndjson` for its default listing. Identifier columns keep their natural width even if the table exceeds the terminal — they are no longer silently truncated.
+
+#### editors running
+
+List the Unity Editor instances currently running and the project each has open, with the editor version and process id per instance:
+
+```bash
+unity editors running
+unity editors running --format json
+```
+
+Detection is cross-platform (process table plus each project's Pipeline lockfile), and the version falls back to a project's `ProjectSettings/ProjectVersion.txt` for editors without the Pipeline package. An empty list is a normal result (exit 0). Honors the global `--format human|json|tsv|ndjson` (and `--json`).
+
+#### editors add
+
+Register one or more existing editor installations by path:
+
+```bash
+unity editors add /path/to/Unity/Editor
+
+# Register multiple at once
+unity editors add /path/one /path/two
+
+# Skip macOS code-signature check (useful for unsigned or side-loaded builds)
+unity editors add /path/to/Unity/Editor --skip-signature-check
+```
+
+#### editors default
+
+```bash
+# Show current default editor
+unity editors default --format json
+
+# Set default by version, alias, or keyword
+unity editors default 6000.0.47f1
+unity editors default latest
+unity editors default lts
+
+# Clear the default
+unity editors default --unset
+```
+
+On a TTY with no arguments, shows an interactive selection prompt.
+
+#### editors path
+
+```bash
+# Print the install directory of an installed editor (local, offline — no release-feed fetch)
+unity editors path 6000.0.47f1
+unity editors path 6000.0.47f1 --architecture arm64 --json
+```
+
+Honors `--architecture` and `--format` / `--json`, and reports ambiguous matches so you can narrow by version or architecture.
+
+#### editors install-path
+
+```bash
+# Show the directory where editors are installed
+unity editors install-path
+
+# Set a new install path
+unity editors install-path --set /path/to/editors
+```
+
+Also available as the top-level `unity install-path` (with an additional `--get` flag). Distinct from `editors path`: `install-path` gets/sets the *root* install directory; `editors path` prints the install directory of *one* editor version.
+
+#### editors info
+
+```bash
+# Show release details for a specific version
+unity editors info 6000.0.47f1 --format json
+```
+
+#### editors upgrade
+
+New in `0.1.0-beta.8`. Upgrade an installed editor to the newest official (f-channel) patch in the same `major.minor` line (e.g. `2022.3.10f1` → `2022.3.62f1`), carrying the installed modules over. The `[editor]` argument accepts an exact version, a `major.minor` line, or the `latest` / `lts` / `default` aliases. Editors install side by side — the old version is kept unless `--replace` (alias `--remove-old`) is passed.
+
+```bash
+# Upgrade a specific editor (or the default / lts / latest) to the newest patch in its line
+unity editors upgrade 2022.3.10f1
+unity editors upgrade lts
+
+# Upgrade every installed editor that has a newer patch
+unity editors upgrade --all --yes --accept-eula
+
+# Report current → target without installing (--check is an alias for --dry-run)
+unity editors upgrade --all --dry-run --format json
+
+# Remove the old editor after a successful upgrade; skip carrying modules; add extra modules
+unity editors upgrade 2022.3.10f1 --replace --yes
+unity editors upgrade 2022.3.10f1 --no-modules
+unity editors upgrade 2022.3.10f1 --module android --module ios
+```
+
+#### editors module / editor module
+
+Module management is exposed under **both** `editors module` and the `editor` (singular) command group. Both share the same subcommands:
+
+```bash
+# List modules for an installed editor
+unity editors module list 6000.0.47f1 --format json
+unity editor module list 6000.0.47f1 --architecture arm64 --format json
+
+# Add modules to an installed editor
+unity editors module add 6000.0.47f1 --module android --module ios
+unity editors module add 6000.0.47f1 --all          # Install every available module
+unity editors module add 6000.0.47f1 --module android --child-modules   # Include child modules
+unity editors module add 6000.0.47f1 --module android --accept-eula      # Accept EULAs automatically
+
+# Remove installed modules from an editor by id (-m/--module, repeatable)
+unity editors module remove 6000.0.47f1 --module android --module ios
+unity editor module remove 6000.0.47f1 -m android -a arm64   # disambiguate side-by-side installs
+unity editors module remove 6000.0.47f1 -m android --yes     # skip the confirm prompt (required non-interactively)
+
+# Refresh module list for a manually located editor
+unity editors module refresh 6000.0.47f1
+```
+
+`module remove` prompts to confirm before deleting the module files; `-y` / `--yes` skips the prompt and is required in non-interactive mode. Supports `-a` / `--architecture` to disambiguate side-by-side installs and the global `--format human|json|tsv|ndjson`.
+
+#### editor add (single path, with module-fetch control)
+
+The `editor add` subcommand is similar to `editors add` but targets a single path and supports skipping the module-fetch step:
+
+```bash
+unity editor add /path/to/Unity/Editor
+
+# Skip fetching module metadata (faster, but modules won't be listed until refreshed)
+unity editor add /path/to/Unity/Editor --no-fetch-modules
+```
+
+---
+
+### Install
+
+```bash
+# Install an editor (interactive version selection if omitted)
+unity install 6000.0.47f1
+
+# Install with specific modules
+unity install 6000.0.47f1 --module windows-mono --module android
+
+# Install a specific changeset by hash
+unity install 6000.0.47f1 --changeset abc123def456
+
+# Include child modules
+unity install 6000.0.47f1 --cm
+
+# Exclude child modules
+unity install 6000.0.47f1 --no-cm
+
+# Install and accept EULAs automatically (CI)
+unity install 6000.0.47f1 --yes --accept-eula
+
+# Force reinstall even if already present
+unity install 6000.0.47f1 --force
+
+# Resume an interrupted download (also recovers orphaned partials left by a crash or kill)
+unity install 6000.0.47f1 --resume
+
+# Dry-run: show what would be installed without doing it
+unity install 6000.0.47f1 --dry-run --format json
+
+# List the editor's available modules and exit without installing
+# (a drop-in alias for `unity modules list <version>`)
+unity install 6000.0.47f1 --list-components --format json
+
+# Space-separated module values after a single -m are equivalent to repeating -m
+unity install 6000.0.47f1 -m android ios          # space-separated
+unity install 6000.0.47f1 -m android -m ios       # repeated flag (same effect)
+
+# Windows: keep the install service unelevated. The Editor's NSIS installer is manifested
+# `highestAvailable`, so it runs unelevated for a STANDARD user (the supported unprivileged
+# install — it reports any dependencies an admin must finish) but still asks for elevation on
+# demand under an administrator account. In CI, where a prompt can't be answered, run the
+# agent elevated instead. Also via UNITY_NO_ELEVATE=1.
+unity install 6000.0.47f1 --no-elevate --yes --accept-eula
+```
+
+When installing an editor with several modules, a failed module no longer aborts the whole batch — `unity install` (and `unity install-modules`) continue with the remaining items and exit non-zero if any failed. Each editor and module is listed as installed (✓), failed (✗), or pending (·); the NDJSON `result` frame carries the same breakdown as an `items` array (each entry has `uid`, `name`, `kind`, `status`), so scripts can tell exactly which modules succeeded even on a non-zero exit.
+
+**NDJSON progress frames** for `unity install` and `unity install-modules` include a `phase: 'download' | 'install'` field so scripts can switch to an indeterminate spinner during the install phase (which is genuinely indeterminate — NSIS on Windows only reports success/failure). During the install phase, `pct` is locked at 50 and only jumps to 100 on completion. Module download/install progress is nested under the parent editor via `parentItemUid`, so consumers see one editor group with its modules rather than one group per module.
+
+On an interactive terminal, `unity install` also reports progress to the terminal application itself via the `OSC 9;4` escape sequence — on Windows Terminal the taskbar icon fills with download/install progress and spinners show as indeterminate, so you don't need to keep the window focused. It's emitted only on a TTY (never in piped or machine-consumed output), always cleared on exit, and ignored by terminals that don't support it.
+
+Module installers honor the per-module install command from the release manifest (e.g. Visual Studio on Windows uses `--passive`, not `/S`); the resolved command is surfaced in `unity modules list --json`. `unity install` self-heals a corrupted partial download by discarding the bad partial and re-downloading; a cross-process install lock prevents two concurrent installs of the same version from corrupting the unpack.
+
+### Uninstall
+
+```bash
+# Uninstall an editor version
+unity uninstall 6000.0.47f1 --yes
+
+# Uninstall a specific architecture
+unity uninstall 6000.0.47f1 --architecture arm64 --yes
+```
+
+---
+
+### Modules — add/list per editor
+
+```bash
+# List modules for an installed editor
+unity modules list 6000.0.47f1 --format json
+
+# Filter by architecture
+unity modules list 6000.0.47f1 --architecture arm64 --format json
+```
+
+`unity modules list` honors `--format ndjson` (empty results emit a clean, empty NDJSON stream).
+
+### install-modules
+
+```bash
+# List available modules without installing
+unity install-modules --editor-version 6000.0.47f1 --list
+
+# Install specific modules
+unity install-modules --editor-version 6000.0.47f1 --module android --module ios
+
+# Install all available modules
+unity install-modules --editor-version 6000.0.47f1 --all --yes
+
+# Include child modules (default behaviour)
+unity install-modules --editor-version 6000.0.47f1 --module android --cm
+
+# Exclude child modules
+unity install-modules --editor-version 6000.0.47f1 --module android --no-cm
+
+# Accept EULAs and dry-run
+unity install-modules --editor-version 6000.0.47f1 --all --accept-eula --dry-run
+
+# Reinstall modules that are already installed (a repair)
+unity install-modules --editor-version 6000.0.47f1 --module android --reinstall
+
+# -f/--force implies --reinstall, auto-includes child modules, and skips confirmation prompts
+unity install-modules --editor-version 6000.0.47f1 --module android --force
+
+# Tune the automatic retry for modules whose download/validation fails intermittently
+# (default retries twice with backoff; 0 disables). Also via UNITY_INSTALL_RETRIES.
+unity install-modules --editor-version 6000.0.47f1 --module android --retries 3
+unity install-modules --editor-version 6000.0.47f1 --module android --retries 0
+
+# Windows: skip the elevated (UAC) install helper (also via UNITY_NO_ELEVATE=1)
+unity install-modules --editor-version 6000.0.47f1 --module android --no-elevate
+```
+
+`--list` and `--all` are mutually exclusive. `--list` is also mutually exclusive with `--module`.
+
+A module whose download or validation fails intermittently — common for large modules such as Android SDK/NDK and OpenJDK — is retried automatically (up to twice with exponential backoff by default) instead of failing the whole run; already-installed modules are never re-downloaded, and retry attempts surface in both human and `--format ndjson` output.
+
+`--module android ios` (space-separated values after a single `--module`) and `--module android --module ios` (repeated flag) are equivalent — both install all listed modules.
+
+Module discovery works for editors registered via `unity editors add <path>` (located editors), not just editors installed by the Hub.
+
+---
+

--- a/skills/unity-cli/references/integration-advanced.md
+++ b/skills/unity-cli/references/integration-advanced.md
@@ -1,0 +1,365 @@
+# Integration & advanced — unity-cli command reference
+
+Part of the **`unity-cli`** skill. See that skill's `SKILL.md` for CLI install, global flags,
+environment variables, exit codes, and common workflows. All global flags (`--format json`,
+`--non-interactive`, `--yes`, `--proxy`, …) apply to every command below.
+
+---
+
+### MCP — Model Context Protocol server (AI agent integration)
+
+New in `0.1.0-beta.8`. `unity mcp` starts a Model Context Protocol server, built into the `unity` binary, that exposes the commands of a connected Unity Editor as MCP tools. AI agent clients connect over stdio, list those tools, and run them. The server starts even when no Editor is running and reports that it isn't connected; commands that a connected Editor adds show up as tools automatically.
+
+```bash
+# Start the MCP stdio server (usually launched by the AI client, not by hand)
+unity mcp
+
+# Pin the server to a specific Unity project (the CLI discovers the running Editor itself)
+unity mcp --project-path /path/to/MyProject
+```
+
+`unity mcp` no longer accepts `--instance <host:port>`: talking to an Editor requires that Editor's per-instance auth token, which a bare host and port can't carry, so the CLI always discovers running Editors itself — run from the project directory or pass `--project-path` to target one. Editors launched to create a new project (`-createproject`) are discovered too.
+
+#### mcp configure — register the server in an AI client
+
+Writes the Unity MCP server entry into an AI client's config in one step, preserving every other key in the file. 16 clients are supported: `claude`, `claude-code`, `cursor`, `vscode`, `vscode-insiders`, `copilot-cli`, `windsurf`, `cline`, `codex`, `kiro`, `trae`, `openclaw`, `antigravity`, `zed`, `continue`, `inspect`.
+
+```bash
+# List all supported clients and their config paths
+unity mcp configure --list
+
+# Configure a client
+unity mcp configure claude
+unity mcp configure claude-code
+
+# Project-local config for clients that support it (e.g. cursor, windsurf)
+unity mcp configure cursor --local
+
+# Pin to a project; skip the "already exists, update?" prompt; preview without writing
+unity mcp configure claude --project-path /path/to/MyProject
+unity mcp configure vscode --yes
+unity mcp configure vscode --dry-run
+```
+
+---
+
+### Connected Editors — pipeline / command / status
+
+> **Promoted to production in `0.1.0-beta.8`.** In earlier betas these were development-only (and the Pipeline package was Unity-internal). They now talk to any running Unity Editor over its Pipeline server, and the supporting Editor-side package (`com.unity.pipeline`) is resolved from the **Unity (UPM) registry** and added to the project's `Packages/manifest.json` — no internal access or manual setup required. The Editor defines each command's parameters, help, and error messages, so the commands a connected Editor exposes are usable without a CLI update.
+
+**Why drive a live Editor instead of a fresh batch job?** `command`, `list`, and `eval` round-trip
+against an already-loaded Editor in roughly **200–600 ms with no script recompile and no domain
+reload** — far cheaper than a cold `unity run` per action. That makes it practical for an agent to
+create GameObjects, edit assets, run a test, or evaluate C# iteratively within a single warm session.
+
+#### Getting an Editor to drive
+
+`command`, `list`, `eval`, and `status` attach to an **already-running** Editor with the Pipeline
+package — they connect to its Pipeline server, they don't start one. One gotcha up front: a bare
+`unity run <project>` (**without** `--command`) is *not* a way to get one — it runs batch mode to
+completion and exits on its own (the log ends `Exiting batchmode successfully now!`). Use one of the
+three patterns below. Any resident Editor (batch or GUI) then answers in ~200–600 ms with no recompile
+and no domain reload, so an agent can iterate in a single session.
+
+**Persistent headless (no GUI) — agent / SSH build box.** Launch the Editor binary directly in batch
+mode and **omit `-quit`** so it stays resident and keeps serving the Pipeline API. The binary lives
+inside the install dir reported by `unity editors --installed` (`location`).
+
+```bash
+unity pipeline install --project-path /path/to/MyProject
+# macOS: the `location` is the .app bundle; the executable is inside it. (Linux: <editor>/Editor/Unity)
+UNITY=/Applications/Unity/Hub/Editor/6000.3.11f1/Unity.app/Contents/MacOS/Unity
+"$UNITY" -batchmode -projectPath /path/to/MyProject -logFile editor.log &   # NO -quit → stays resident
+# Drive it — target the project explicitly (see the status caveat):
+unity command --project-path /path/to/MyProject                            # list what it exposes
+unity list    --project-path /path/to/MyProject                            # discover tools
+unity command eval "return Application.unityVersion;" --project-path /path/to/MyProject
+```
+
+> **`unity status` caveat (verified):** a batch-mode Editor launched this way *does* serve commands,
+> but is **not** listed by `unity status` (its lockfile heartbeat differs from a GUI Editor's). Confirm
+> reachability with `unity command`/`unity list --project-path <project>`, not `unity status`.
+
+**Warm / interactive.** Use an Editor you already have open, or `unity open <project>` (GUI, stays
+resident). Unlike the batch case, its Pipeline server *does* register with `unity status` (state
+`ready`), so `unity status` gates readiness. Drive it the same way (the CLI auto-discovers it; pass
+`--project-path` to disambiguate when several are open).
+
+```bash
+unity open /path/to/MyProject
+unity status --format json                                 # wait until an instance shows state "ready"
+unity command eval "return Application.unityVersion;"
+```
+
+**One-shot (CI).** `unity run <project> --command <name> -- <args>` boots a batch Editor, runs one
+registered command, prints its result, and exits — a fresh boot each time (no warm reuse). Parse with
+`--format ndjson`, since the Editor writes its own log to stdout alongside the result.
+
+```bash
+unity run /path/to/MyProject --command spawn_light --format ndjson -- --name Sun
+```
+
+A resident Editor (headless or GUI) holds a license seat until it exits; the one-shot path releases it
+on exit.
+
+#### pipeline (alias: pipe) — manage the Unity Pipeline package
+
+```bash
+# List the Editors the CLI can reach and the Pipeline package status of each.
+# Also shows each project's installed Pipeline version and flags when the registry has a newer one.
+unity pipeline list --format json
+
+# Install / update the Pipeline package into a project (auto-detects project if omitted)
+unity pipeline install
+unity pipeline install --project-path /path/to/MyProject
+unity pipeline install --force          # always rewrite the manifest to the latest version
+
+# Install a specific version (validated against the registry first; overwrites any pinned version).
+# NOTE: the flag is --package-version, NOT --version (which collides with the global -V, --version).
+unity pipeline install --package-version 0.3.0-exp.1
+
+# Upgrade the package to the latest, but only when the registry has a newer one
+# (otherwise reports it's already up to date and leaves manifest.json untouched).
+# Requires the package to be installed already.
+unity pipeline upgrade
+unity pipeline upgrade --project-path /path/to/MyProject
+
+# List every version published to the Unity registry, newest first (marks the current latest)
+unity pipeline list-versions --format json
+```
+
+`pipeline install` options: `--project-path <path>`, `--force`, `--package-version <version>`. The package is resolved from the Unity registry and written to `Packages/manifest.json`. Unlike `pipeline install --force` (which always rewrites to latest), `upgrade` compares the pinned version first.
+
+When multiple Editors are running, `install` and `upgrade` consider only the editors that actually need the operation (`install` → editors without the package; `upgrade` → editors behind the registry's latest). If exactly one needs it, that editor is chosen automatically; if none do, the command reports there's nothing to do; if several do, an interactive terminal shows a selector while non-interactive contexts (machine output, non-TTY, or `--non-interactive`) error and list the projects so you can pass `--project-path`.
+
+#### command (aliases: cmd, request) — send commands to a running Unity Editor
+
+Forwards a command to a connected Editor. Run it with no arguments to list the commands the connected Editor exposes.
+
+```bash
+# List all commands available on the connected Unity Editor
+unity command
+unity command --format json
+
+# Execute a specific command (names/params come from the Editor)
+unity command editor_play
+unity command log_editor "Hello from CLI"
+unity command editor_status --includeMemory true
+
+# Capture a Scene/Game view screenshot (forwarded to the Editor's screenshot command, new in 0.1.0-beta.8)
+unity command screenshot --output ./shot.png --width 1920 --height 1080
+
+# Target a specific project (the CLI discovers the running Editor itself) or a Player runtime
+unity command editor_play --project-path /path/to/MyProject
+unity command <command> --runtime "MyGame"
+unity command <command> --runtime-path /path/to/port-file
+
+# Set a timeout (default: 30 seconds)
+unity command editor_play --timeout 60
+```
+
+#### Available in production — the common live commands
+
+Everything reached through **`unity command <name>`** is part of the project's `com.unity.pipeline` package and works against a normal, **production** Editor (or a Player runtime via `--runtime`) — it is *not* development-gated. Don't refuse a live-Editor task on the assumption that driving the Editor requires a development build — it doesn't.
+
+The Pipeline package ships a set of built-in scene/GameObject commands. The common ones (names and parameters come from the Editor, so confirm the exact set with `unity command` / `unity list`):
+
+| Command | Does |
+|---|---|
+| `create_gameobject` | Create a GameObject in the active scene |
+| `find_gameobjects` | Query the active scene for GameObjects |
+| `get_scene_hierarchy` | Print the active scene's hierarchy |
+| `set_transform` | Set a GameObject's position / rotation / scale |
+| `add_component` | Add a component to a GameObject |
+| `rename_gameobject` / `delete_gameobject` | Rename or delete a GameObject |
+| `save_scene` / `save_all` | Save the active scene, or all dirty scenes and assets |
+| `create_script` → `recompile` → `attach_script` | Add a new C# script, rebuild, then attach it to a GameObject |
+
+The **authoritative** catalog is always `unity command --format json` — every registered command with its full parameter schema. The table above just jump-starts common tasks so you don't have to dump-and-grep first.
+
+Some projects (and Pipeline package versions) register an `eval` — and `eval_file` — command on the
+Editor side, so you can run C# through the connected Editor in a production build:
+`unity command eval "return Application.unityVersion;"` or `unity command eval_file snippet.cs`.
+Availability depends on the Editor/package, so discover it at runtime with `unity command` / `unity list`
+rather than assuming it.
+
+If no editor with a reachable Pipeline server is found, the command errors with guidance (make sure the editor is running and its Pipeline server is up).
+
+`unity command` no longer accepts `--instance <host:port>` — the CLI discovers running Editors itself, so run from the project directory or pass `--project-path` to target one.
+
+#### list — discover a connected Editor's tools
+
+`unity list` queries the connected Unity Editor (via the Pipeline package) and prints every registered tool with its name, description, group, and parameter schema. Use it to discover what's callable in the current Editor session without reading source code — especially when the project registers custom `[CliCommand]` tools (see *Authoring custom `[CliCommand]` tools* below). Unlike `unity command` (which lists *and* runs), `list` is discovery/introspection only.
+
+```bash
+unity list
+unity list --format json
+```
+
+Honors the global `--quiet` and `--no-banner` flags. On a connection failure it suggests `unity pipeline list` to diagnose.
+
+#### status — live state of connected editors
+
+```bash
+# Show port, state, project, version, PID for every connected Unity Editor
+unity status --format json
+
+# Filter to one instance
+unity status --port 8765
+unity status --project megacity
+```
+
+Reads the lockfile the Pipeline package writes per running Editor (faster and more CI-friendly than `pipeline list`). Stale-heartbeat instances are reported as `unreachable` without an HTTP probe. With `--format json`/`ndjson`, emits a `success: false` envelope (`STATUS_NO_INSTANCES` / `STATUS_ALL_UNREACHABLE`) and a non-zero exit when no Editor is reachable, so CI scripts can gate on Editor availability.
+
+#### Recovering from Safe Mode (connection fails because of compile errors)
+
+When a project has **C# compile errors**, the Unity Editor starts in **Safe Mode**. The Pipeline
+package is a normal package, so it **does not load in Safe Mode** — which means `unity command`,
+`unity list`, `unity status`, and the MCP server **cannot connect** to that Editor. This is a
+deadlock for an agent that wants to fix the compile errors *through* the Editor: the Editor is
+unreachable *because of* the very errors you want to fix. (Deeper package-in-Safe-Mode support is
+on Unity's roadmap post-Unity 7.0; until then, recover with the loop below.)
+
+**Don't treat "can't connect" as "no Editor, so hand-edit files blindly."** Diagnose Safe Mode
+first, then fix the compile errors at the source and restart:
+
+1. **Recognize the signal.** `unity command` / `unity list` fail with *"Cannot connect to … Pipeline
+   server"*, or `unity status` shows no `ready` instance — even though an Editor is open for the
+   project.
+
+2. **Confirm Safe Mode.** Run `unity pipeline list`. It probes each running Editor and reports Safe
+   Mode explicitly. The **human** output prints `Editor is in Safe Mode - Pipeline server disabled`, a
+   `SafeMode Instances: N detected` summary line, and the hint *"Fix compilation errors and restart
+   Unity to exit Safe Mode."* With **`--format json`** those human strings are *not* emitted — read the
+   structured fields instead: `summary.instancesInSafeMode` (> 0), or per instance
+   `instances[].safeMode.detected` (`true`).
+
+   ```bash
+   unity pipeline list                  # human: reads the Safe Mode warning + "fix and restart" hint
+   unity pipeline list --format json    # machine: check .summary.instancesInSafeMode / .instances[].safeMode.detected
+   ```
+
+3. **Read the compile errors from the Editor log.** A normal GUI Editor writes a single **global**
+   `Editor.log` per user (not per project) — the same log the CLI's own Safe Mode detector reads. Read
+   its tail and grep for compiler errors (`error CS####` / `Scripts have compiler errors`):
+
+   | Platform | Global `Editor.log` path |
+   |---|---|
+   | macOS | `~/Library/Logs/Unity/Editor.log` |
+   | Windows | `%USERPROFILE%\AppData\Local\Unity\Editor\Editor.log` |
+   | Linux | `~/.config/unity3d/Editor.log` |
+
+   ```bash
+   # macOS example — surface the compile errors that forced Safe Mode
+   grep -iE 'error CS[0-9]{4}|Scripts have compiler errors' ~/Library/Logs/Unity/Editor.log | tail -40
+   ```
+
+   > The global log reflects the **most recent** Editor session, so if several Editors are open, target
+   > the stuck one by the path *you* launched it with: a headless Editor started with `-logFile <path>`
+   > (see the persistent-headless launch above) writes there instead — read that file.
+   >
+   > `unity logs` reads the **CLI's own** log, not this `Editor.log` — read the file above directly.
+
+4. **Fix the compile errors in the C# source.** This is the one situation where hand-editing project
+   files is correct: the Editor is unreachable, so you can't drive it — edit the `.cs` files to
+   resolve the errors reported in step 3.
+
+5. **Restart Unity to leave Safe Mode.** Relaunch the Editor so it recompiles the now-fixed scripts:
+   for a headless/agent box, kill the old process and re-run the persistent-batch launch above; for a
+   GUI, `unity open /path/to/MyProject`.
+
+6. **Re-verify reachability.** Poll `unity pipeline list` (or `unity status` for a GUI Editor) until
+   the Pipeline server is reachable again, then resume driving the Editor with `unity command` /
+   `unity list`. If it's still in Safe Mode, a compile error remains — return to step 3.
+
+#### Authoring custom `[CliCommand]` tools
+
+The command surface is extensible from the **project** side: tag a `static` method with `[CliCommand]`
+and it becomes callable via `unity command <name>` (warm) or `unity run --command <name>` (one-shot),
+and discoverable via `unity list` — no CLI release required. Parameters, help text, and errors are
+surfaced to the CLI automatically. `[CliCommand]` and `[CliArg]` live in the `Unity.Pipeline.Commands`
+namespace (assembly `Unity.Pipeline`, from `com.unity.pipeline`); `MainThreadRequired` and `RuntimeOnly`
+are **named properties on `[CliCommand]`**, not separate attributes.
+
+```csharp
+using Unity.Pipeline.Commands;   // [CliCommand] / [CliArg] — assembly: Unity.Pipeline
+using UnityEngine;
+
+public static class MyPipelineCommands
+{
+    // Warm:     unity command spawn_light --name Sun
+    // One-shot: unity run <project> --command spawn_light -- --name Sun
+    [CliCommand("spawn_light", "Create a GameObject with a Light component",
+                MainThreadRequired = true /* default true; set false only for thread-safe work */)]
+    public static string SpawnLight([CliArg("name", "GameObject name")] string name = "Light")
+    {
+        var go = new GameObject(name, typeof(Light));
+        return go.name;
+    }
+}
+```
+
+- The method must be `static` (any accessibility works). Place it in an **Editor** assembly (an
+  `Editor/` folder, or an asmdef that references `Unity.Pipeline`) so it loads with the Pipeline server.
+- `MainThreadRequired` defaults to **true** — keep it for anything that reads or mutates engine/editor
+  state (scene graph, assets, serialized objects); set it `false` only for pure, thread-safe work.
+- `RuntimeOnly = true` hides the command from an Editor server's listing (Player/dev-build only); reach
+  such a command with `unity command <command> --runtime <runtime>`. 
+- After adding or changing a command, rebuild with `unity command recompile` (poll
+  `unity command recompile_status` until `completed`), then `unity list` to confirm it registered. The
+  Pipeline package also ships built-in commands, including `eval` / `eval_file` (run C# in the Editor).
+
+---
+
+### Shell — interactive REPL
+
+`unity shell` boots the CLI once and runs many commands in the same warm process, avoiding the per-command startup cost of separate `unity …` invocations. Enter any command **without** the `unity` prefix.
+
+```bash
+unity shell
+# unity> status --format json
+# unity> config proxy http://proxy:8080
+# unity> config proxy            # the write above is visible to this read
+# unity> exit
+```
+
+- Arguments are tokenized shell-style (single/double quotes; unquoted Windows backslash paths are preserved).
+- Leave with `exit`, `quit`, or Ctrl-D; blank lines and `#` comments are ignored.
+- Ctrl-C cancels a cancellable running command (such as `build`) and returns to the prompt; for a command that doesn't yet support cancellation the first Ctrl-C is held (with a hint) and a second quick press force-quits the session.
+- The prompt terminator is a heavy angle (`❯`) on Unicode-capable terminals, falling back to `>`; it shows the previous command's exit code when it was non-zero.
+- **Command history** persists across sessions — press ↑/↓ to recall previous commands (stored under the CLI data directory, capped at the most recent 1000 entries). Secret-bearing flag values (`--android-keystore-password`, `--client-secret`, `--serial`, `--git-token`, and the other keystore/token flags) are masked to `***` before being written to disk.
+- **Tab completion** — press Tab to complete command names, subcommands, option flags, and option values (for example `--format`) against the live command tree, plus the shell's own builtins.
+- Interactive prompts (confirmations, sign-in) work inside the shell, and a write in one command (`auth logout`, `config`, `editors default`, …) is visible to the next.
+- Piped/scripted sessions (`… | unity shell`) run every line and exit with the first command that failed (0 when every command succeeds), so a batch is usable in automation with `$?`. Interactive sessions still exit 0.
+
+#### Session context & defaults
+
+Set shell-local defaults so you stop repeating flags. Every setting is per-session and still overridable by a per-command flag:
+
+```bash
+# unity> use project /path/to/MyGame   # active project → seeds UNITY_PROJECT_PATH for later commands
+# unity> use org my-org-id             # active Cloud org → seeds UNITY_CLOUD_ORG
+# unity> set format json               # default output format for the session
+# unity> set verbose on                # default --verbose on|off
+# unity> set banner off                # hide the branded banner for the session
+# unity> context                       # show the current context (bare `use` does the same)
+# unity> unset format                  # clear one setting (format | verbose | banner | project | org)
+```
+
+`UNITY_PROJECT_PATH` and `UNITY_CLOUD_ORG` are also honored as environment variables by the project-path and cloud commands.
+
+#### Machine/agent mode — `--protocol ndjson`
+
+`unity shell --protocol ndjson` runs the same warm process but speaks a framed **request/response** protocol over stdio instead of a human prompt — for automated callers (AI agents, CI, orchestration) that want the startup-amortization benefit without screen-scraping. The caller writes **one JSON request per line** and reads **exactly one JSON result per line**, processed serially:
+
+```text
+$ unity shell --protocol ndjson
+{"id":"1","argv":["editors","--installed"]}
+{"id":"1","exitCode":0,"envelope":{"success":true,"command":"editors","data":[…],"errors":[],"warnings":[]}}
+{"type":"shutdown"}
+```
+
+- **Request:** an optional `id` (echoed back for correlation), plus either `argv` (a pre-tokenized array — preferred) or `command` (a raw string, tokenized like the interactive shell). Do not include the leading `unity`. `{"type":"shutdown"}` ends the session (as does EOF).
+- **Response:** the echoed `id` (or `null`), the in-band `exitCode`, and `envelope` — the same `{ success, command, data, errors, warnings }` shape as `--format json`.
+- Commands run headlessly (an interactive prompt fails fast); malformed lines or unknown commands produce an error frame rather than ending the session.
+- **Trusted input only.** Machine mode runs the exact commands the caller sends, on the local machine as the current user — the same authority as typing them at your own terminal. Drive it only with commands you construct yourself; never pass commands assembled from untrusted or third-party content (web pages, issue text, unvetted model output), the same way you would never pipe untrusted text into a shell.

--- a/skills/unity-cli/references/projects-templates.md
+++ b/skills/unity-cli/references/projects-templates.md
@@ -1,0 +1,367 @@
+# Projects, releases & templates — unity-cli command reference
+
+Part of the **`unity-cli`** skill. See that skill's `SKILL.md` for CLI install, global flags,
+environment variables, exit codes, and common workflows. All global flags (`--format json`,
+`--non-interactive`, `--yes`, `--proxy`, …) apply to every command below.
+
+---
+
+### Projects — list, open, create, register, clone, link
+
+```bash
+# List registered projects
+unity projects list --format json
+
+# Register an existing project
+unity projects add /path/to/MyProject
+
+# Remove from registry (does not delete files)
+unity projects remove /path/to/MyProject
+
+# Show project details
+unity projects info /path/to/MyProject --format json
+
+# Open a project in the editor
+unity open /path/to/MyProject
+
+# Open with a specific editor version
+unity open /path/to/MyProject --editor-version 6000.0.47f1
+
+# Pass extra Unity arguments
+unity open /path/to/MyProject --args "-logFile output.log"
+
+# Pass a build target (forwarded to Unity as -buildTarget / -buildTargetGroup)
+unity open /path/to/MyProject --build-target StandaloneOSX
+unity open /path/to/MyProject --build-target-group Standalone
+
+# Version shorthand (equivalent to open with --editor-version)
+unity 6000.0.47f1 /path/to/MyProject
+```
+
+The project argument is matched against the Hub registry first (exact name or path opens immediately; a glob like `"My Game*"` prompts when multiple match); with no registry match it falls back to treating the argument as a filesystem path. Path matching is tolerant of casing, separator direction, and a trailing slash — resolved against real filesystem path identity — so a registered project is found even when the path is spelled differently, while two genuinely distinct case-variant folders on a case-sensitive volume stay distinct. `unity open` forwards `--args` to the Editor correctly on all platforms (including Windows).
+
+**Reserved flags — do NOT pass these via `--args`.** `-projectPath` is managed by the command (Unity's parser is last-wins, so forwarding it would silently redirect the open to a different project), and `-useHub`/`-hubIPC` are deliberately never passed — they tell the Editor a Unity Hub manages its session, which the CLI is not. Passing any of them fails fast, before launch, with exit code 6:
+
+```
+Error: Forwarded argument '-useHub' conflicts with a reserved Unity flag managed by this command. Remove it from `--args`.
+```
+
+All three spellings Unity accepts are rejected (`-useHub`, `--useHub`, `-useHub=1`, case-insensitively). Everything else — `-logFile <path>`, `-nographics`, custom flags your project reads — is forwarded verbatim.
+
+#### projects create
+
+Create a project. On a TTY, prompts for any missing options (parent directory, editor version, template). In CI, pass `--non-interactive` or pipe stdin to suppress prompts and rely on stored defaults. The first positional argument is the project **name**; `--path` sets the parent directory:
+
+```bash
+unity projects create MyGame --editor-version 6000.0.47f1 --template com.unity.template.3d
+
+# Place the project in a specific directory
+unity projects create MyGame --path /path/to/projects --editor-version 6000.0.47f1
+
+# --template also accepts a .tgz file path or a directory, not just a registered template id
+unity projects create MyGame --template /path/to/template.tgz
+```
+
+**Cloud linking during creation:**
+
+```bash
+# Create and link a NEW Unity Cloud project as part of creation
+unity projects create MyGame --cloud --cloud-org <id-or-name>
+
+# Link an EXISTING cloud project instead
+unity projects create MyGame --cloud-project <id-or-name>
+```
+
+**Source-control during creation** — publish the new project to a fresh repository:
+
+```bash
+unity projects create MyGame \
+  --vcs github \
+  --git-namespace my-org \
+  --git-repo my-game \
+  --git-visibility private \
+  --git-default-branch main \
+  --git-token-stdin
+```
+
+Source-control flags (shared with `projects link vcs`): `--vcs github|gitlab|uvcs`, `--git-namespace <name>`, `--git-repo <name>`, `--git-visibility private|public|internal` (default private), `--git-default-branch <name>`, `--git-token <pat>` / `--git-token-stdin`, `--no-initial-commit`, `--git-lfs`, and `--vcs-region <name>` for Unity Version Control.
+
+**Flag names differ by subcommand:** `projects create` and `projects link vcs` use `--git-namespace` / `--git-repo`, while `projects clone` (below) uses `--vcs-namespace` / `--vcs-repo`. Copy the names for the exact command you're running, and confirm with `--help` if unsure.
+
+#### projects new
+
+Create a project without any interactive prompts — resolves missing options from stored defaults, never asks the user. The first positional argument is the project **name**; `--path` sets the parent directory:
+
+```bash
+# All omitted options resolve from stored defaults
+unity projects new MyGame
+
+# Override stored defaults with explicit values
+unity projects new MyGame --path /path/to/projects --editor-version 6000.0.47f1 --template com.unity.template.3d
+
+# Open the project immediately after creation
+unity projects new MyGame --open
+```
+
+#### projects clone
+
+Clone a remote repository and register the Unity project it contains. Works across providers:
+
+```bash
+# Clone by full repo URL / shorthand
+unity projects clone --vcs github --vcs-namespace my-org --vcs-repo my-game --path ./MyGame
+
+# Check out a specific ref (branch, sha, or UVCS changeset)
+unity projects clone --vcs uvcs --vcs-namespace my-org --vcs-repo my-game --ref main
+
+# Authenticate with a personal access token (prefer stdin)
+unity projects clone --vcs gitlab --vcs-namespace my-org --vcs-repo my-game --git-token-stdin
+
+# Project lives in a subdirectory of the repo
+unity projects clone --vcs github --vcs-namespace my-org --vcs-repo monorepo \
+  --path ./repo --project-path packages/MyGame
+```
+
+Options: `--vcs github|gitlab|uvcs`, `--vcs-namespace <name>`, `--vcs-repo <name>`, `--ref <branch|sha|changeset>` (an all-digit ref is treated as a Unity Version Control changeset, anything else as a branch), `--path <dest>` (clone destination), `--project-path <subpath>` (project subdirectory), `--git-token <pat>` / `--git-token-stdin`, `--json`. Git LFS assets are fetched as pointer files only.
+
+#### projects pin / unpin
+
+```bash
+# Pin a project to the top of the list
+unity projects pin /path/to/MyProject
+
+# Unpin
+unity projects unpin /path/to/MyProject
+```
+
+#### projects size
+
+Report a project's on-disk footprint broken down by top-level folder (Assets, Library, Packages, …) with a total, so you can see how much is regenerable build state (Library, Temp) versus source and assets:
+
+```bash
+# Size of one project (defaults to the current project when the argument is omitted)
+unity projects size /path/to/MyProject
+
+# Summarize every registered project, largest first
+unity projects size --all
+
+# Machine output — raw bytes instead of readable KB/MB/GB units
+unity projects size --all --json
+```
+
+Human output uses readable units; `--json` (and `--format ndjson`) emit raw byte counts.
+
+#### projects require
+
+Ensure the editor version required by a project is installed, installing it if needed:
+
+```bash
+unity projects require /path/to/MyProject --yes
+```
+
+On a TTY with no path, prompts interactively.
+
+#### projects upgrade
+
+Upgrade a project to a different Unity editor version. `--to` is required:
+
+```bash
+unity projects upgrade --to 6000.0.47f1
+unity projects upgrade /path/to/MyProject --to 6000.0.47f1 --yes
+```
+
+#### projects export / import
+
+```bash
+# Export the project registry to a file (or stdout if -o is omitted)
+unity projects export -o projects.json
+
+# Import a previously exported registry
+unity projects import projects.json
+unity projects import --input projects.json
+```
+
+#### projects open / link / unlink
+
+```bash
+# Open a registered project by name, fuzzy title match, or path
+unity projects open MyProject
+# (the top-level `unity open` is the same thing)
+
+# --- Cloud links ---
+# Connect an existing local project to a Unity Cloud project
+unity projects link cloud /path/to/MyProject --cloud-org <id-or-name>
+# Disconnect from its Unity Cloud project
+unity projects unlink cloud /path/to/MyProject
+
+# --- Version-control links ---
+# Publish a local project to a NEW GitHub / GitLab / Unity Version Control repository
+unity projects link vcs /path/to/MyProject \
+  --vcs github --git-namespace my-org --git-repo my-game --git-token-stdin
+# Remove a project's git remotes (the remote repositories are NOT deleted)
+unity projects unlink vcs /path/to/MyProject
+# Also detach the Unity Version Control workspace
+unity projects unlink vcs /path/to/MyProject --unlink-workspace
+```
+
+`link vcs` shares the source-control flag set documented under `projects create`. `link cloud` / `link vcs` accept `--cloud-org <id-or-name>` (env `UNITY_CLOUD_ORG`).
+
+---
+
+### Releases — browse Unity versions
+
+```bash
+# List recent releases
+unity releases --format json
+
+# Filter by stream (alpha, beta, lts, tech)
+unity releases --stream lts --format json
+unity releases --stream tech --format json
+unity releases --stream beta --format json
+
+# LTS only shorthand
+unity releases --lts --format json
+
+# Filter from a year onward
+unity releases --since 2023 --format json
+
+# Paginate
+unity releases --limit 10 --skip 20 --format json
+```
+
+---
+
+### Templates
+
+```bash
+# List templates for an editor version (uses default editor if --editor is omitted)
+unity templates list --editor 6000.0.47f1 --format json
+
+# List only locally installed templates
+unity templates list --editor 6000.0.47f1 --installed --format json
+
+# Filter by type (core, learning, sample, custom, new, all) — case-insensitive
+unity templates list --editor 6000.0.47f1 --type core --format json
+unity templates list --editor 6000.0.47f1 --type learning --format json
+unity templates list --editor 6000.0.47f1 --type sample --format json
+unity templates list --editor 6000.0.47f1 --type new --format json
+unity templates list --editor 6000.0.47f1 --type all --format json  # no-op, returns everything
+
+# List only user-generated (custom) templates
+unity templates list --editor 6000.0.47f1 --custom --format json
+# --type custom is an alias for --custom
+unity templates list --editor 6000.0.47f1 --type custom --format json
+
+# --custom and --type are mutually exclusive — using both is an error (exit 1)
+
+# Show template details
+unity templates info com.unity.template.3d --editor 6000.0.47f1 --format json
+
+# Create a custom template from an existing Unity project
+# --name and --display-name are REQUIRED
+unity templates create /path/to/MyProject \
+  --name com.myorg.template.mytemplate \
+  --display-name "My Template"
+
+# With all optional options
+unity templates create /path/to/MyProject \
+  --name com.myorg.template.mytemplate \
+  --display-name "My Template" \
+  --description "A starting point for our projects" \
+  --template-version 1.0.0 \
+  --output /path/to/templates/dir \
+  --keep-embedded-packages \
+  --keep-project-settings \
+  --overwrite
+
+# JSON output (includes path to created .tgz archive)
+unity templates create /path/to/MyProject \
+  --name com.myorg.template.mytemplate \
+  --display-name "My Template" \
+  --json
+
+# NDJSON streaming — emits progress frames then a result frame
+unity templates create /path/to/MyProject \
+  --name com.myorg.template.mytemplate \
+  --display-name "My Template" \
+  --format ndjson
+```
+
+**`templates create` key notes:**
+- `--name` must be a valid npm package name (e.g. `com.myorg.template.mytemplate`)
+- `--output` overrides the Hub-configured user templates directory
+- `--overwrite` replaces an existing archive of the same name without error
+- On success, prints the path to the created `.tgz` archive
+- Created templates appear in `unity templates list --editor <v> --custom`
+
+```bash
+# Delete a user-generated custom template (prompts for confirmation)
+unity templates delete com.myorg.template.mytemplate --editor 6000.0.47f1
+
+# Skip the confirmation prompt (CI-friendly)
+unity templates delete com.myorg.template.mytemplate --editor 6000.0.47f1 --yes
+
+# JSON output
+unity templates delete com.myorg.template.mytemplate --editor 6000.0.47f1 --yes --json
+```
+
+**`templates delete` key notes:**
+- Only user-generated templates (created via Hub UI or `templates create`) can be deleted
+- Attempting to delete a built-in Unity template exits with a descriptive error (exit 6)
+- Attempting to delete a template that doesn't exist exits with a descriptive error (exit 6)
+- In interactive mode, prompts for confirmation before deleting; use `--yes` to skip
+- On success, the template no longer appears in `unity templates list --editor <v> --custom`
+
+```bash
+# Get/set/reset the default storage path for custom templates
+# Print current configured templates location
+unity templates location
+
+# Set a new default templates directory (must exist as a directory)
+unity templates location --set /path/to/templates
+
+# Reset templates location to the Hub default
+unity templates location --reset
+
+# JSON output for any variant
+unity templates location --json
+unity templates location --set /path/to/templates --json
+unity templates location --reset --json
+```
+
+**`templates location` key notes:**
+- `--set` and `--reset` are mutually exclusive (using both is an error)
+- `--set` validates that the path exists and is a directory (exits 2 if not)
+- `--reset` restores the Hub default templates path
+- JSON output: `{ "path": "..." }` inside the standard envelope
+
+```bash
+# Edit a user-generated (custom) template's metadata
+# At least one of --display-name, --description, --template-version,
+# --preview-image, --remove-preview-image is required
+unity templates edit com.myorg.template.mytemplate --editor 6000.0.47f1 --display-name "My Updated Template"
+
+# Update multiple fields at once
+unity templates edit com.myorg.template.mytemplate \
+  --editor 6000.0.47f1 \
+  --display-name "My Updated Template" \
+  --description "A new description for the template" \
+  --template-version 1.1.0
+
+# Replace / remove preview image
+unity templates edit com.myorg.template.mytemplate --editor 6000.0.47f1 --preview-image /path/to/image.png
+unity templates edit com.myorg.template.mytemplate --editor 6000.0.47f1 --remove-preview-image
+
+# JSON / NDJSON output (--yes required because these are non-interactive)
+unity templates edit com.myorg.template.mytemplate --editor 6000.0.47f1 --display-name "Updated" --yes --json
+```
+
+**`templates edit` key notes:**
+- Only works on user-generated (custom) templates; built-in templates cannot be edited
+- Use `--editor` to specify which editor version's template list to search, or omit to use the stored default
+- `--preview-image <path>` resolves to an absolute path before passing to the service
+- `--remove-preview-image` is only applied when no valid `--preview-image` path is given; if both are passed with a valid image path, the new image wins and `--remove-preview-image` is ignored
+- On success (human format), prints the updated template's display name
+
+---
+


### PR DESCRIPTION
Adds the `unity-cli` skill — Unity CLI usage, and driving a connected Editor from the command line. Verbatim: no content changes, 10 files.

## Why this belongs in the plugin

A set of skills that need a live Editor is coming next — audio mixer routing, sprite slicing, NavMesh setup, URP post-processing and others. Each of them needs the same prerequisites established before it can do anything: the CLI installed, an Editor connected, the project's `com.unity.pipeline` package present, and a way to tell a genuinely absent Editor apart from one stuck in Safe Mode after a compile error.

Restating that in every skill would mean one copy per skill, all drifting apart, each carrying install commands that go stale as the CLI changes. **So those skills delegate to this one instead**, in a few lines: *"the `unity-cli` skill owns getting you there"*. That only works if it's here — a skill can't reference a sibling that isn't in the same plugin.

It also closes a gap for the common case. Most people install the CLI from the docs and never install its agent skill separately, so making it a prerequisite the user has to supply would strand them. Shipping it in the plugin means anyone who installs the plugin has it.

## Relationship to the copy in the skills repo

The same skill is published as `unity-cli` in [`Unity-Technologies/skills`](https://github.com/Unity-Technologies/skills). This copy tracks the CLI's current version, which is ahead of that one by about 180 lines across 8 files.

The difference is not cosmetic. The newer content includes the **Safe Mode** guidance in both places it belongs — when a project has C# compile errors the Editor boots into Safe Mode, the Pipeline package never loads, and `status` / `command` / `list` all fail to connect in a way that looks identical to "no Editor running". Telling those two apart is exactly what the Editor-dependent skills need, and it's the reason this copy is taken from the CLI's own version rather than the published one.

Worth syncing the skills-repo copy separately; that's a change in that repo, not this one.

## Review notes

Nothing was adapted, so there's no port to check — the useful review is whether the content is accurate for the current CLI, since that's what it documents. Frontmatter is unchanged, including `allowed-tools: Bash`; this is the one skill in the plugin that legitimately needs a shell.