### PR TITLE
fix: decouple four shipped skills from the AI Assistant runtime

### DIFF
--- a/skills/asset-transformer-toolkit/references/rulesets-and-actions.md
+++ b/skills/asset-transformer-toolkit/references/rulesets-and-actions.md
@@ -29,56 +29,45 @@ RuleSets support conversion to json. This will include information about the Act
 #### Step 1: Load RuleSet
 - Use AssetDatabase.LoadAssetAtPath to load the asset from memory.
 
-#### Step 2: Construct RunCommand
+#### Step 2: Construct the script
 - Read the API reference for the RuleSet class. Also read the API reference for the Rule and RuleBlock classes if required.
-- Construct a RunCommand using the APIs from those files. Here is an example of a RunCommand script that adds a Decimate Action to a RuleSet:
+- Construct a script using the APIs from those files, to run as C# in a live Editor. Here is an
+  example that adds a Decimate Action to a RuleSet:
 
 ```csharp
 using UnityEngine;
 using UnityEditor;
 using UnityEditor.PixyzPlugin4Unity.RuleEngine;
 
-internal class CommandScript : IRunCommand
-{
-    public void Execute(ExecutionResult result)
-    {
-        string path = "Assets/Rulesets/OptimizationRuleSet.asset";
-        RuleSet ruleSet = AssetDatabase.LoadAssetAtPath<RuleSet>(path);
-        
-        if (ruleSet == null)
-        {
-            result.LogError("RuleSet not found at {0}", path);
-            return;
-        }
+string path = "Assets/Rulesets/OptimizationRuleSet.asset";
+RuleSet ruleSet = AssetDatabase.LoadAssetAtPath<RuleSet>(path);
 
-        result.RegisterObjectModification(ruleSet);
+if (ruleSet == null)
+    throw new System.Exception($"RuleSet not found at {path}");
 
-        if (ruleSet.RulesCount == 0)
-        {
-            result.LogError("No rules found in RuleSet {0}", path);
-            return;
-        }
+Undo.RecordObject(ruleSet, "Add Decimate action");
 
-        Rule rule = ruleSet.GetRule(0);
-        
-        // Decimate Action ID is 277054868
-        RuleBlock decimateBlock = new RuleBlock(277054868);
-        
-        rule.AppendBlock(decimateBlock);
-        
-        EditorUtility.SetDirty(ruleSet);
-        AssetDatabase.SaveAssets();
+if (ruleSet.RulesCount == 0)
+    throw new System.Exception($"No rules found in RuleSet {path}");
 
-        result.Log("Added Decimate action to {0} (Rule index 0)", path);
-    }
-}
+Rule rule = ruleSet.GetRule(0);
+
+// Decimate Action ID is 277054868
+RuleBlock decimateBlock = new RuleBlock(277054868);
+
+rule.AppendBlock(decimateBlock);
+
+EditorUtility.SetDirty(ruleSet);
+AssetDatabase.SaveAssets();
+
+return $"Added Decimate action to {path} (Rule index 0)";
 ```
 
-A proper RunCommand for modifying a RuleSet has the following traits:
+A proper script for modifying a RuleSet has the following traits:
 - Does not use the ScriptableObject API (this bypasses necessary event triggers).
 
 #### Step 3: Validation
-- Execute the RunCommand script.
+- Run the script as C# in a live Editor.
 - Validate the RuleSet against the validation checklist.
 
 
@@ -144,7 +133,7 @@ All paths are exclusive.
 - If a preset is used, avoid changing values the preset changed unless requested otherwise.
 
 **Safety & Constraints**
-1. **One-Strike Rule**: If `ATTAssistantUtilities.SetActionParameter` throws an AITypeSecurityException, you MUST TERMINATE the task immediately. Do NOT use RunCommand, reflection, or any other method to bypass this. Follow the steps in Path A as your final actions.
+1. **One-Strike Rule**: If `ATTAssistantUtilities.SetActionParameter` throws an AITypeSecurityException, you MUST TERMINATE the task immediately. Do NOT use raw C# execution, reflection, or any other method to bypass this. Follow the steps in Path A as your final actions.
 
 
 ### Running RuleSets

--- a/skills/implement-in-app-purchases/references/api-notes.md
+++ b/skills/implement-in-app-purchases/references/api-notes.md
@@ -22,7 +22,7 @@
 - [Failure Description Property Names](#failure-description-property-names)
 - [CrossPlatformValidator](#crossplatformvalidator)
 - [Interface Hierarchy](#interface-hierarchy)
-- [IRunCommand Template: Fetch Products](#iruncommand-template-fetch-products)
+- [Template: Fetch Products](#template-fetch-products)
 
 ## Anti-Hallucination: v5 vs Legacy API
 
@@ -518,45 +518,42 @@ StoreController implements:
   IPurchaseService   - PurchaseProduct(), ConfirmPurchase(), FetchPurchases(), Apple/Google purchase extensions
 ```
 
-## IRunCommand Template: Fetch Products
+## Template: Fetch Products
 
 ```csharp
 using UnityEngine;
 using UnityEngine.Purchasing;
 using System.Collections.Generic;
 
-namespace Unity.AI.Assistant.Agent.Dynamic.Extension.Editor
+public static class FetchProductsExample
 {
-    internal class CommandScript : IRunCommand
+    // Store callbacks arrive after Connect() returns, so this reports through the
+    // Editor console rather than a return value.
+    public static async void Run()
     {
-        public string Title => "Fetch IAP products";
-        public string Description => "Connects to the store and fetches product information.";
-        public async void Execute(ExecutionResult result)
+        var store = UnityIAPServices.StoreController();
+
+        // Subscribe to events BEFORE Connect
+        store.OnStoreConnected += () =>
         {
-            var store = UnityIAPServices.StoreController();
-
-            // Subscribe to events BEFORE Connect
-            store.OnStoreConnected += () =>
+            var products = new List<ProductDefinition>
             {
-                var products = new List<ProductDefinition>
-                {
-                    new ProductDefinition("com.mygame.coins100", ProductType.Consumable),
-                    new ProductDefinition("com.mygame.removeads", ProductType.NonConsumable)
-                };
-
-                store.OnProductsFetched += (fetched) =>
-                {
-                    foreach (var p in fetched)
-                        result.Log($"{p.definition.id}: {p.metadata.localizedPriceString}");
-                };
-                store.OnProductsFetchFailed += (failure) => result.LogError($"Product fetch failed: {failure.FailureReason}");
-
-                store.FetchProducts(products);
+                new ProductDefinition("com.mygame.coins100", ProductType.Consumable),
+                new ProductDefinition("com.mygame.removeads", ProductType.NonConsumable)
             };
-            store.OnStoreDisconnected += (failure) => result.LogError($"Store disconnected: {failure.Message}");
 
-            await store.Connect();
-        }
+            store.OnProductsFetched += (fetched) =>
+            {
+                foreach (var p in fetched)
+                    Debug.Log($"{p.definition.id}: {p.metadata.localizedPriceString}");
+            };
+            store.OnProductsFetchFailed += (failure) => Debug.LogError($"Product fetch failed: {failure.FailureReason}");
+
+            store.FetchProducts(products);
+        };
+        store.OnStoreDisconnected += (failure) => Debug.LogError($"Store disconnected: {failure.Message}");
+
+        await store.Connect();
     }
 }
 ```

--- a/skills/setup-audiorandomcontainer/references/api.md
+++ b/skills/setup-audiorandomcontainer/references/api.md
@@ -26,7 +26,7 @@
 - ❌ **DON'T**: Use `AudioSource.resource` (will be deprecated)
 
 ### Scope Restrictions
-- `AudioRandomContainer` is **internal only** - use within `RunCommand` context
+- `AudioRandomContainer` is **internal only** - reach it from C# running inside the Editor
 - **Never reference** this type in generated project scripts (causes compilation errors)
 - **Always import** `UnityEngine.Audio` namespace when working with this type
 

--- a/skills/setup-game-inputs/references/input-system.md
+++ b/skills/setup-game-inputs/references/input-system.md
@@ -29,25 +29,28 @@
 
 1. Package Installation Check
 First of all **verify that the com.unity.inputsystem package is installed**
-**Install if Missing:** If InputSystem is not installed, use the `RunCommand` tool with the following C# code to install it:
+**Install if Missing:** add the package to the project manifest — `Packages/manifest.json`,
+under `dependencies`:
+
+```json
+"com.unity.inputsystem": "<current 1.x version>"
+```
+
+Don't invent the version string. Read the current one from the Unity registry —
+`https://packages.unity.com/com.unity.inputsystem` lists every published version — or copy the version an
+adjacent Unity package in this manifest already uses. A version that doesn't exist makes
+Unity fail resolution **silently**, so a wrong guess looks like nothing happened.
+
+Unity resolves the new dependency the next time the Editor regains focus. This needs no
+Editor connection, which is why it's the default route here.
+
+If you do have a live Editor to run C# in, the equivalent is:
+
 ```csharp
-using UnityEngine;
-using UnityEditor;
 using UnityEditor.PackageManager;
 
-namespace Unity.AI.Assistant.Agent.Dynamic.Extension.Editor
-{
-    internal class CommandScript : IRunCommand
-    {
-        public string Title => "Install Input System package";
-        public string Description => "This command will request the Unity Package Manager to install the Input System package.";
-        public void Execute(ExecutionResult result)
-        {
-            var request = Client.Add("com.unity.inputsystem");
-            result.Log("Requested installation of com.unity.inputsystem. You can monitor progress in the Package Manager window.");
-        }
-    }
-}
+var request = Client.Add("com.unity.inputsystem");
+UnityEngine.Debug.Log("Requested com.unity.inputsystem. Progress shows in the Package Manager window.");
 ```
 **Proceed:** Only continue to the next steps once InputSystem is confirmed to be installed.
 
@@ -65,61 +68,63 @@ Changing the Active Input Handling setting requires an Editor restart.
 
 **DO NOT** search or grep `ProjectSettings/ProjectSettings.asset`, `ProjectSettings/EditorBuildSettings.asset`, or any other project settings files to find the project-wide actions asset. The reference is stored internally via `EditorBuildSettings` config objects and is **not human-readable** in project files. Attempting to grep these files will fail and waste time.
 
-**The ONLY correct way** to check and manage project-wide actions is via `RunCommand` using the C# API:
+**The ONLY correct way** to check and manage project-wide actions is the C# API below, run in a live Editor:
 
 **To check if project-wide actions are assigned and inspect their contents:**
+
+Two routes. The file route needs no Editor: `.inputactions` assets are JSON on disk, so
+glob for `*.inputactions` and read one directly to see its action maps, actions and
+bindings. What a file cannot tell you is which asset is *assigned* project-wide — that
+lives in project settings.
+
+With a live Editor to run C# in:
+
 ```csharp
 using UnityEngine;
 using UnityEngine.InputSystem;
 
-namespace Unity.AI.Assistant.Agent.Dynamic.Extension.Editor
+var actions = InputSystem.actions;
+if (actions == null)
 {
-    internal class CommandScript : IRunCommand
+    Debug.Log("No project-wide Input Actions asset is currently assigned.");
+    Debug.Log("To create one: Edit > Project Settings > Input System Package > Create a new project-wide Action Asset");
+
+    // Also check if any .inputactions assets exist in the project that could be assigned
+    var guids = UnityEditor.AssetDatabase.FindAssets("t:InputActionAsset");
+    if (guids.Length > 0)
     {
-        public string Title => "Check Project-Wide Input Actions";
-        public string Description => "Checks whether a project-wide Input Actions asset is assigned and reports its contents.";
-        public void Execute(ExecutionResult result)
+        Debug.Log($"Found {guids.Length} InputActionAsset(s) in the project that could be assigned:");
+        foreach (var guid in guids)
         {
-            var actions = InputSystem.actions;
-            if (actions == null)
-            {
-                result.Log("No project-wide Input Actions asset is currently assigned.");
-                result.Log("To create one: Edit > Project Settings > Input System Package > Create a new project-wide Action Asset");
-
-                // Also check if any .inputactions assets exist in the project that could be assigned
-                var guids = UnityEditor.AssetDatabase.FindAssets("t:InputActionAsset");
-                if (guids.Length > 0)
-                {
-                    result.Log($"Found {guids.Length} InputActionAsset(s) in the project that could be assigned:");
-                    foreach (var guid in guids)
-                    {
-                        var assetPath = UnityEditor.AssetDatabase.GUIDToAssetPath(guid);
-                        result.Log($"  - {assetPath}");
-                    }
-                }
-                return;
-            }
-
-            var path = UnityEditor.AssetDatabase.GetAssetPath(actions);
-            result.Log($"Project-wide actions asset: {actions.name} ({path})");
-            result.Log($"Action Maps ({actions.actionMaps.Count}):");
-            foreach (var map in actions.actionMaps)
-            {
-                result.Log($"  - {map.name} ({map.actions.Count} actions)");
-                foreach (var action in map.actions)
-                {
-                    result.Log($"      {action.name} (Type: {action.type}, ExpectedControlType: {action.expectedControlType}, Bindings: {action.bindings.Count})");
-                }
-            }
-            result.Log($"Control Schemes ({actions.controlSchemes.Count}):");
-            foreach (var scheme in actions.controlSchemes)
-            {
-                result.Log($"  - {scheme.name}");
-            }
+            var assetPath = UnityEditor.AssetDatabase.GUIDToAssetPath(guid);
+            Debug.Log($"  - {assetPath}");
         }
     }
+    return "no project-wide actions assigned";
 }
+
+var path = UnityEditor.AssetDatabase.GetAssetPath(actions);
+var report = new System.Text.StringBuilder();
+report.AppendLine($"Project-wide actions asset: {actions.name} ({path})");
+report.AppendLine($"Action Maps ({actions.actionMaps.Count}):");
+foreach (var map in actions.actionMaps)
+{
+    report.AppendLine($"  - {map.name} ({map.actions.Count} actions)");
+    foreach (var action in map.actions)
+    {
+        report.AppendLine($"      {action.name} (Type: {action.type}, ExpectedControlType: {action.expectedControlType}, Bindings: {action.bindings.Count})");
+    }
+}
+report.AppendLine($"Control Schemes ({actions.controlSchemes.Count}):");
+foreach (var scheme in actions.controlSchemes)
+{
+    report.AppendLine($"  - {scheme.name}");
+}
+return report.ToString();
 ```
+
+Return the report rather than only logging it: logs land in the Editor console, while the
+returned value is what comes back to whoever ran the snippet.
 
 **To assign an existing .inputactions asset as project-wide:**
 ```csharp
@@ -127,7 +132,7 @@ var asset = UnityEditor.AssetDatabase.LoadAssetAtPath<InputActionAsset>("Assets/
 if (asset != null)
 {
     InputSystem.actions = asset;
-    result.Log($"Assigned '{asset.name}' as project-wide actions.");
+    UnityEngine.Debug.Log($"Assigned '{asset.name}' as project-wide actions.");
 }
 ```
 Note: `InputSystem.actions` can only be assigned in Edit mode (not Play mode) and the asset must be a persistent file on disk inside the Assets folder.
@@ -138,7 +143,7 @@ var guids = UnityEditor.AssetDatabase.FindAssets("t:InputActionAsset");
 foreach (var guid in guids)
 {
     var assetPath = UnityEditor.AssetDatabase.GUIDToAssetPath(guid);
-    result.Log($"Found: {assetPath}");
+    UnityEngine.Debug.Log($"Found: {assetPath}");
 }
 ```
 
@@ -272,8 +277,8 @@ public class MyPlayerScript : MonoBehaviour, IGameplayActions
 ```
 
 * **Option 3 - Project-Wide Actions** (Simplest)
-    - First check if a project-wide asset is assigned using the `RunCommand` script from Section 1 "Check Project-Wide Actions". Do NOT grep ProjectSettings files.
-    - If no project-wide asset is assigned, either create one via the `RunCommand` asset creation API (see API note 1) and assign it with `InputSystem.actions = asset;`, or instruct the user to go to Edit > Project Settings > Input System Package > Create a new project-wide Action Asset.
+    - First check if a project-wide asset is assigned using the script from Section 1 "Check Project-Wide Actions". Do NOT grep ProjectSettings files.
+    - If no project-wide asset is assigned, either create one via the asset creation API (see API note 1) and assign it with `InputSystem.actions = asset;`, or instruct the user to go to Edit > Project Settings > Input System Package > Create a new project-wide Action Asset.
     - Project-wide actions are enabled by default and ready to use.
     - Hook actions into gameplay using `InputSystem.actions.FindAction("Move")`. Cache references in `Start()`, do NOT call `FindAction` every frame.
 
@@ -349,7 +354,7 @@ Summarize what was created/changed:
 
 ## Important API notes
 
-0. Never edit inputaction asset Json directly, always use `RunCommand` with InputActionAsset API to edit the asset.
+0. Never edit inputaction asset Json directly, always use the InputActionAsset API, run in a live Editor, to edit the asset.
 
 1. CreateAsset() should not be used to create a file of type 'inputactions'.
 To create and save the '.inputaction' files use the next code example:
@@ -362,9 +367,9 @@ File.WriteAllText(path, json);
 
 2. Do NOT use 'Input.' class to handle inputs, it might result with exceptions at runtime. Use `InputSystem.actions.FindAction()` or action references instead.
 
-3. To add or remove input control scheme use `RunCommand` with `asset.AddControlScheme(InputControlScheme)`
+3. To add or remove input control scheme use `asset.AddControlScheme(InputControlScheme)`
 
-4. To add an action to a map use `RunCommand` with the next API example `public static InputAction AddAction(this InputActionMap map, string name, InputActionType type = InputActionType.Value, string binding = null, string interactions = null, string processors = null, string groups = null, string expectedControlLayout = null)`
+4. To add an action to a map use the API example that follows `public static InputAction AddAction(this InputActionMap map, string name, InputActionType type = InputActionType.Value, string binding = null, string interactions = null, string processors = null, string groups = null, string expectedControlLayout = null)`
 
 5. To add a composite binding use `AddCompositeBinding`:
 ```csharp
@@ -405,7 +410,7 @@ var action = asset.FindAction("Player/Jump");
 ```
 
 9. CRITICAL: Project-Wide Actions are NOT in ProjectSettings files.
-**NEVER** search, grep, or read `ProjectSettings/ProjectSettings.asset`, `ProjectSettings/EditorBuildSettings.asset`, or any other settings files to find input actions. The project-wide actions reference is stored internally via `EditorBuildSettings` config objects (binary format, not greppable). Always use `RunCommand` with `InputSystem.actions` to read the current project-wide actions, and `InputSystem.actions = asset` to assign them. See Section 1 "Check Project-Wide Actions" for the complete RunCommand script.
+**NEVER** search, grep, or read `ProjectSettings/ProjectSettings.asset`, `ProjectSettings/EditorBuildSettings.asset`, or any other settings files to find input actions. The project-wide actions reference is stored internally via `EditorBuildSettings` config objects (binary format, not greppable). Always use `InputSystem.actions` to read the current project-wide actions, and `InputSystem.actions = asset` to assign them. See Section 1 "Check Project-Wide Actions" for the complete script.
 
 10. CRITICAL: Correct Unity Input System API Names
 
@@ -912,8 +917,8 @@ The following exceptions exist and may be used regardless of Active Input Handli
 
 ### 10. Editing .inputactions JSON Directly
 **Problem:** Manual JSON edits can corrupt the asset, break binding IDs, or lose data.
-**Solution:** Always use the InputActionAsset API via `RunCommand` to modify assets programmatically.
+**Solution:** Always modify assets programmatically through the InputActionAsset API, run in a live Editor.
 
 ### 11. Searching ProjectSettings Files for Input Actions
 **Problem:** Grepping or reading `ProjectSettings/ProjectSettings.asset` or other settings files to find the project-wide actions asset. The reference is stored via `EditorBuildSettings` config objects in binary format and is not searchable in text files. This always fails and wastes multiple tool calls.
-**Solution:** Always use `RunCommand` with `InputSystem.actions` to check the current project-wide actions. See Section 1 "Check Project-Wide Actions" for the complete script.
+**Solution:** Always use `InputSystem.actions` to check the current project-wide actions. See Section 1 "Check Project-Wide Actions" for the complete script.


### PR DESCRIPTION
Four skills already in this plugin tell the agent to author C# that only compiles inside Unity AI Assistant. This removes that coupling. Reference files only — no `SKILL.md` changes, and every `description` is untouched.

## The defect

These skills came from a context where a built-in tool executed C# in the Editor. That tool handed the script an injected object to report through, and the scripts were written as a class implementing an interface the runtime supplied:

```csharp
namespace Unity.AI.Assistant.Agent.Dynamic.Extension.Editor
{
    internal class CommandScript : IRunCommand
    {
        public void Execute(ExecutionResult result)
        {
            ...
            result.Log("Requested installation of com.unity.inputsystem.");
```

None of `IRunCommand`, `ExecutionResult`, or the injected `result` exists outside that runtime. An agent following these files writes code that **does not compile in the user's project** — and the namespace advertises a product they aren't running.

It was easy to miss because it hides where nobody looks: the bodies of these skills are clean, and all of it lives in the `references/` files the body points at. `setup-game-inputs` carried 27 sites in a 919-line reference while its `SKILL.md` had none.

## What changed

| | |
|---|---|
| `setup-game-inputs` | 27 sites |
| `asset-transformer-toolkit` | 12 sites |
| `implement-in-app-purchases` | 8 sites |
| `setup-audiorandomcontainer` | 1 site |

The rewrite is mechanical, four substitutions:

- The class wrapper and its namespace are removed — the snippet body stands on its own.
- `result.LogError(...)` / `result.Error(...)` on an abort path becomes `throw new System.Exception(...)`, so a failure is loud instead of a log line the caller may never read.
- `result.Log(...)` becomes `Debug.Log(...)` when it's operator-facing, or a **returned** value when the caller needs to read it back. This is the one that needs judgment rather than substitution.
- `result.RegisterObjectModification(o)` becomes `Undo.RecordObject(o, "…")`.

Two changes go slightly further than renaming, because the instruction itself assumed the old runtime:

**`setup-game-inputs` installed the Input System package by calling `Client.Add` through the Editor.** It now edits `Packages/manifest.json` instead, which needs no Editor connection at all — the right default for a skill that otherwise doesn't require one. The C# route stays, as the alternative for when a live Editor is available.

**`setup-game-inputs` also inspected project-wide Input Actions only through C#**, while explicitly forbidding a file-based route. That prohibition is correct for *which asset is assigned* — that genuinely lives in project settings — but `.inputactions` assets are JSON on disk, so reading one directly is a valid route for their contents. Both are now described, with the distinction spelled out.

## Verification

A structural check over every file in every skill — not just `SKILL.md` — reports zero remaining references to the AI Assistant tool vocabulary, execution contract, or namespace across the plugin.

Not verified by execution: these are reference documents, and the snippets in them are illustrative. Where a snippet's *behavior* changed rather than its wrapper (the two `setup-game-inputs` items above), that's called out rather than presented as equivalent.