### PR TITLE
feat: add the audio-setup-mixers skill

### DIFF
--- a/skills/audio-setup-mixers/SKILL.md
+++ b/skills/audio-setup-mixers/SKILL.md
@@ -34,6 +34,19 @@ from `unity command --format json` rather than assuming one — the inline form 
 `eval_file` for running a snippet from a file. **Check the catalog before reaching for
 `eval_file`; it is frequently absent.** `unity command` defaults to a 30 second timeout.
 
+### Passing C# to `eval`
+
+`eval` compiles a **statement block, not a file**. Two consequences, both of which cause a
+compile error rather than a warning:
+
+- **No `using` directives.** The compiler reads `using UnityEngine;` as a resource-disposal
+  statement and rejects it (`CS0210`).
+- **Types must be fully qualified.** A bare `AssetDatabase` or `Volume` does not resolve
+  (`CS0246` / `CS0103`), and a bare `Object` is ambiguous with `object` (`CS0104`).
+
+Where a snippet below is written as a file — with usings, for readability, or because it is
+meant to be saved into the project — qualify the types before passing it to `eval`.
+
 ## Step 1: Pre-flight
 If the user hasn't explicitly asked for Audio Mixers, confirm that they want to proceed with setting them up.
 

--- a/skills/audio-setup-mixers/SKILL.md
+++ b/skills/audio-setup-mixers/SKILL.md
@@ -1,14 +1,25 @@
 ---
 name: audio-setup-mixers
-description: Scans the scene and audio assets to appropriately route Audio Sources into existing Audio Mixer Groups or new ones if necessary. Use when user asks about adjusting sound levels or quality in general, cleaning up mixer assignments or creating mixers.
+description: Scans the scene and audio assets to appropriately route Audio Sources into existing Audio Mixer Groups, classifying each source by what it plays. Use when the user asks about cleaning up mixer assignments, routing audio through a mixer, or which group a sound belongs in. Creating mixers and groups, and setting volumes, are not automated — the skill inventories what exists and asks the user to add anything missing.
 required_editor_version: ">=6000.3.13"
 ---
 # Audio Mixer Setup
 
-The authoring APIs this skill uses (`AudioMixerController`, `AudioMixerGroupController`)
-live in `UnityEditor.Audio` and only exist inside a running Editor. There is no file
-you can write to create or re-route a mixer, so this skill needs a live Editor it can
-execute C# in. Step 0 establishes that before anything else.
+Routing an Audio Source to a mixer group is a scene edit that only a running Editor can
+make, so this skill needs a live Editor it can execute C# in. Step 0 establishes that
+before anything else.
+
+**What this skill automates, and what it hands back to you.** Inspecting mixers and
+routing Audio Sources into groups is entirely public Unity API, and that is the tedious
+part — walking dozens of sources and classifying them by what they play. Creating a mixer
+or a group has no public API; it exists only on types Unity does not commit to keeping
+stable. So this skill will not create groups behind your back. It inventories what exists,
+proposes the routing, asks you to add any missing group in the Audio Mixer window, and
+then does all the routing itself.
+
+That is a deliberate limit, not a gap to work around. Do not reach for reflection to
+create groups, and do not hand-edit a `.mixer` file — mixer structure is not safely
+authorable blind.
 
 ## Step 0: Confirm you can run C# in the Editor
 
@@ -50,9 +61,17 @@ meant to be saved into the project — qualify the types before passing it to `e
 ## Step 1: Pre-flight
 If the user hasn't explicitly asked for Audio Mixers, confirm that they want to proceed with setting them up.
 
-Then find existing mixers by running the snippet from [references/api.md](references/api.md)
-through the Editor as described in Step 0, and **use the referenced API** to understand
-their hierarchy and enumerate the leaf Mixer Group names.
+Then inventory what already exists with the mixer-inventory snippet in
+[references/api.md](references/api.md), run through the Editor as described in Step 0. That gives
+you every mixer in the project and the group names in each.
+
+It returns a flat list of groups, not the parent/child tree. That is enough to route into, and it
+is all the public API exposes. If the hierarchy matters for the conversation, ask the user to look
+at the Audio Mixer window and describe it — don't reach for the non-public tree API to find out.
+
+**If the project has no mixer at all,** say so and stop rather than improvising one: creating a
+mixer has no public API. Ask the user to create one (Window → Audio → Audio Mixer, then the **+**
+next to Mixers), and pick up from here once it exists.
 
 ## Step 2: Find scene references
 Find all Audio Source components, look at their assigned Generator asset names, and generalize a fitting class or category of the sound name, ideally something already existing. 
@@ -65,18 +84,36 @@ Examples for Audio Clip asset names:
 If the assigned asset isn't descriptive or non-existing, try to look at the GameObject name or potential adjacent MonoBehaviour names.
 Ask to create an Uncategorized group if it seems hard or confidence is low in classifying how an Audio Source is being used.
 
-## Step 3: Suggest and create new Mixer Groups
-Suggest the compiled changelist and revise with user. 
-WAIT for the user to respond before proceeding.
+## Step 3: Agree the group list, and get any missing groups created
+Present the classification from Step 2 as a proposed routing — each Audio Source and the group you
+intend to send it to — and revise it with the user.
 
-See if there's a good existing Audio Mixer with a fitting name and reasonable overlap in Mixer Group names, and suggest that OR offer to create a new Audio Mixer specific to this scene regardless.
+**WAIT for the user to respond before proceeding.**
 
-**If** reusing an existing mixer and new groups need to be added, confirm the suggested changes with the user and wait before proceeding.
+Where the mixer's existing groups already cover the categories, prefer them over new names, even
+when the existing name is not the one you'd have chosen. Reusing `Foley` beats introducing `SFX`
+alongside it.
 
-## Step 4: Walk Audio Sources and assign Audio Mixer Groups
-Repeat the process now with settled Mixer Group names.
+For categories with no matching group, you cannot create the group — there is no public API for it.
+Hand it over precisely, naming the mixer and the exact group names, as shown at the end of
+[references/api.md](references/api.md). Then **re-run the inventory snippet to confirm the groups
+exist and check their spelling** before routing. Don't assume the user did it, and don't assume
+they spelled it the way you asked.
 
-The Audio Mixer Group property of the Audio Source should be updated to point to the classified group.
+## Step 4: Route the Audio Sources
+With the group list settled and confirmed present, assign each Audio Source's output group using the
+routing snippet in [references/api.md](references/api.md). It is public API throughout, and it wraps
+the whole pass in a single undo step so the user can back all of it out at once.
+
+Two things to report rather than assume:
+
+- **Any `NO SUCH GROUP` entries the snippet returns.** That means a group you expected is not in the
+  mixer — usually a spelling difference. Resolve it with the user, don't silently skip the source.
+- **The scene was modified, not the mixer asset.** Routing lives on the Audio Source, so it only
+  persists once the scene is saved. Tell the user, and save only with their agreement.
+
+**Volume, effects, and re-parenting are out of scope.** Those live on non-public API. If the user
+asks for them, say the routing is done and point them at the Audio Mixer window for the mix itself.
 
 ## References
 See [references/api.md](references/api.md)

--- a/skills/audio-setup-mixers/SKILL.md
+++ b/skills/audio-setup-mixers/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: audio-setup-mixers
 description: Scans the scene and audio assets to appropriately route Audio Sources into existing Audio Mixer Groups, classifying each source by what it plays. Use when the user asks about cleaning up mixer assignments, routing audio through a mixer, or which group a sound belongs in. Creating mixers and groups, and setting volumes, are not automated — the skill inventories what exists and asks the user to add anything missing.
-required_editor_version: ">=6000.3.13"
 ---
 # Audio Mixer Setup
 
@@ -90,9 +89,11 @@ intend to send it to — and revise it with the user.
 
 **WAIT for the user to respond before proceeding.**
 
-Where the mixer's existing groups already cover the categories, prefer them over new names, even
-when the existing name is not the one you'd have chosen. Reusing `Foley` beats introducing `SFX`
-alongside it.
+Prefer an existing group when it genuinely covers the category, even if you'd have named it
+differently. But **don't collapse categories that a mixing engineer would keep apart** — Foley is a
+subset of SFX, not another word for it, so a gunshot does not belong in a `Foley` group just because
+one exists. When the existing groups only partly cover your categories, say which ones fit and which
+need a new group, and let the user decide.
 
 For categories with no matching group, you cannot create the group — there is no public API for it.
 Hand it over precisely, naming the mixer and the exact group names, as shown at the end of
@@ -105,10 +106,17 @@ With the group list settled and confirmed present, assign each Audio Source's ou
 routing snippet in [references/api.md](references/api.md). It is public API throughout, and it wraps
 the whole pass in a single undo step so the user can back all of it out at once.
 
-Two things to report rather than assume:
+**Key the mapping on the identifier you classified by.** Step 2 reads the clip asset name first and
+only falls back to the GameObject name, so the mapping accepts either — the two are different
+identifiers and keying on the wrong one drops sources.
+
+Three things to report rather than assume:
 
 - **Any `NO SUCH GROUP` entries the snippet returns.** That means a group you expected is not in the
   mixer — usually a spelling difference. Resolve it with the user, don't silently skip the source.
+- **Any `NOT IN THE MAPPING` entries.** Those are Audio Sources your classification missed. Reporting
+  a successful routing while sources were quietly left unrouted is the worst outcome here, because it
+  reads as success.
 - **The scene was modified, not the mixer asset.** Routing lives on the Audio Source, so it only
   persists once the scene is saved. Tell the user, and save only with their agreement.
 

--- a/skills/audio-setup-mixers/SKILL.md
+++ b/skills/audio-setup-mixers/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: audio-setup-mixers
+description: Scans the scene and audio assets to appropriately route Audio Sources into existing Audio Mixer Groups or new ones if necessary. Use when user asks about adjusting sound levels or quality in general, cleaning up mixer assignments or creating mixers.
+required_editor_version: ">=6000.3.13"
+---
+# Audio Mixer Setup
+
+The authoring APIs this skill uses (`AudioMixerController`, `AudioMixerGroupController`)
+live in `UnityEditor.Audio` and only exist inside a running Editor. There is no file
+you can write to create or re-route a mixer, so this skill needs a live Editor it can
+execute C# in. Step 0 establishes that before anything else.
+
+## Step 0: Confirm you can run C# in the Editor
+
+Every C# step below runs inside a live Editor through the Unity CLI. **The `unity-cli` skill
+owns getting you there** — installing the CLI, confirming a connected Editor, adding the
+project's `com.unity.pipeline` package, telling a genuinely absent Editor apart from one
+stuck in Safe Mode, and discovering the Editor's command catalog. Follow it first; don't
+re-derive any of it here.
+
+Two things it can't know for you:
+
+- **You need `eval` in particular**, not just a reachable Editor. Confirm it appears in the
+  catalog. Its presence depends on the Pipeline package version, not on the CLI, so a
+  healthy install can still lack it — if it's missing, say so and stop.
+- **Do not fall back to editing `.mixer` files by hand.** Mixer routing is not safely
+  authorable blind, so an unreachable Editor is a stop, not a cue to improvise.
+
+Once `eval` is available, that is how each C# step below runs.
+
+Run C# through the connected Editor with the `eval` command. Discover its parameter shape
+from `unity command --format json` rather than assuming one — the inline form is
+`unity command eval --code '<snippet>'`, and some Pipeline versions also register
+`eval_file` for running a snippet from a file. **Check the catalog before reaching for
+`eval_file`; it is frequently absent.** `unity command` defaults to a 30 second timeout.
+
+## Step 1: Pre-flight
+If the user hasn't explicitly asked for Audio Mixers, confirm that they want to proceed with setting them up.
+
+Then find existing mixers by running the snippet from [references/api.md](references/api.md)
+through the Editor as described in Step 0, and **use the referenced API** to understand
+their hierarchy and enumerate the leaf Mixer Group names.
+
+## Step 2: Find scene references
+Find all Audio Source components, look at their assigned Generator asset names, and generalize a fitting class or category of the sound name, ideally something already existing. 
+Examples for Audio Clip asset names:
+- "FootStep4_Sound" -> Foley
+- "Dialogue_Female_Scene4" -> Vox/Voice/Dialogue
+- "GunShot" -> SFX
+- "Menu_Theme_Variation" -> Music
+
+If the assigned asset isn't descriptive or non-existing, try to look at the GameObject name or potential adjacent MonoBehaviour names.
+Ask to create an Uncategorized group if it seems hard or confidence is low in classifying how an Audio Source is being used.
+
+## Step 3: Suggest and create new Mixer Groups
+Suggest the compiled changelist and revise with user. 
+WAIT for the user to respond before proceeding.
+
+See if there's a good existing Audio Mixer with a fitting name and reasonable overlap in Mixer Group names, and suggest that OR offer to create a new Audio Mixer specific to this scene regardless.
+
+**If** reusing an existing mixer and new groups need to be added, confirm the suggested changes with the user and wait before proceeding.
+
+## Step 4: Walk Audio Sources and assign Audio Mixer Groups
+Repeat the process now with settled Mixer Group names.
+
+The Audio Mixer Group property of the Audio Source should be updated to point to the classified group.
+
+## References
+See [references/api.md](references/api.md)

--- a/skills/audio-setup-mixers/references/api.md
+++ b/skills/audio-setup-mixers/references/api.md
@@ -64,8 +64,7 @@ foreach (var source in sources)
 {
     var group = source.outputAudioMixerGroup;
     rows.Add($"{source.gameObject.name}: clip={(source.clip != null ? source.clip.name : "<none>")}, "
-           + $"group={(group != null ? group.name : "<none — routes to Master>")}, "
-           + $"spatialBlend={source.spatialBlend}");
+           + $"group={(group != null ? group.name : "<none — routes to Master>")}");
 }
 return rows.Count == 0 ? "no Audio Sources in the open scene" : string.Join("\n", rows);
 ```
@@ -79,31 +78,46 @@ This is the one write this skill performs. `AudioSource.outputAudioMixerGroup` i
 public `AudioMixerGroup`, and the objects returned by `FindMatchingGroups` are assignable to it, so
 there is no cast and no reflection.
 
-Pass the mapping as pairs of GameObject name and target group name.
+**Key the mapping on whichever identifier you actually classified by.** Step 2 classifies from the
+**clip asset name** first and falls back to the GameObject name, so the mapping has to accept either
+— keying it on GameObject name alone silently drops every source you classified by its clip.
 
 ```csharp
 var mixer = UnityEditor.AssetDatabase.LoadAssetAtPath<UnityEngine.Audio.AudioMixer>(
     "Assets/Audio/TheMixer.mixer");
+
+// Keys may be a clip asset name or a GameObject name — whichever you classified from.
 var assignments = new System.Collections.Generic.Dictionary<string, string> {
-    { "Footsteps", "SFX" },
-    { "MenuMusic", "Music" },
+    { "FootStep4_Sound", "Foley" },   // clip name
+    { "MenuMusic",       "Music" },   // GameObject name
 };
 
 var sources = UnityEngine.Object.FindObjectsByType<UnityEngine.AudioSource>(
     UnityEngine.FindObjectsInactive.Include, UnityEngine.FindObjectsSortMode.None);
 
 var done = new System.Collections.Generic.List<string>();
-var missing = new System.Collections.Generic.List<string>();
+var noSuchGroup = new System.Collections.Generic.List<string>();
+var unassigned = new System.Collections.Generic.List<string>();
 
 UnityEditor.Undo.IncrementCurrentGroup();
 UnityEditor.Undo.SetCurrentGroupName("Route Audio Sources to mixer groups");
 
 foreach (var source in sources)
 {
-    if (!assignments.TryGetValue(source.gameObject.name, out var wanted)) { continue; }
+    var clipName = source.clip != null ? source.clip.name : null;
+    string wanted = null;
+    if (clipName != null) { assignments.TryGetValue(clipName, out wanted); }
+    if (wanted == null) { assignments.TryGetValue(source.gameObject.name, out wanted); }
+
+    if (wanted == null)
+    {
+        // Never skip silently — an unmatched source is a result the user has to see.
+        unassigned.Add($"{source.gameObject.name} (clip={clipName ?? "<none>"})");
+        continue;
+    }
 
     var group = System.Array.Find(mixer.FindMatchingGroups(""), g => g.name == wanted);
-    if (group == null) { missing.Add($"{source.gameObject.name} -> {wanted}"); continue; }
+    if (group == null) { noSuchGroup.Add($"{source.gameObject.name} -> {wanted}"); continue; }
 
     UnityEditor.Undo.RegisterCompleteObjectUndo(source, "Route Audio Source");
     source.outputAudioMixerGroup = group;
@@ -115,17 +129,21 @@ UnityEditor.Undo.FlushUndoRecordObjects();
 UnityEditor.Undo.CollapseUndoOperations(UnityEditor.Undo.GetCurrentGroup());
 
 var report = $"routed {done.Count}: {string.Join(", ", done)}";
-if (missing.Count > 0) { report += $"\nNO SUCH GROUP (create it first): {string.Join(", ", missing)}"; }
+if (noSuchGroup.Count > 0) { report += $"\nNO SUCH GROUP (create it first): {string.Join(", ", noSuchGroup)}"; }
+if (unassigned.Count > 0) { report += $"\nNOT IN THE MAPPING (unrouted): {string.Join(", ", unassigned)}"; }
 return report;
 ```
 
-Two things to carry through to the user:
+Three things to carry through to the user:
 
 - **The scene changed, not the mixer asset.** `outputAudioMixerGroup` lives on the Audio Source, so
   the routing only persists once the scene is saved
   (`UnityEditor.SceneManagement.EditorSceneManager.SaveOpenScenes()`). Say so rather than assuming.
 - **Report the `NO SUCH GROUP` list explicitly.** A group the user hasn't created yet is the normal
   case in this flow, not an error to swallow. Show it and ask them to add those groups.
+- **Report `NOT IN THE MAPPING` too.** Those are sources your classification missed. Reporting
+  "routed 4" while three sources were quietly skipped is the worst outcome available here, because it
+  reads as success.
 
 ## Asking the user to add a group
 

--- a/skills/audio-setup-mixers/references/api.md
+++ b/skills/audio-setup-mixers/references/api.md
@@ -1,0 +1,57 @@
+## Architecture
+
+All `AudioMixer`s in the editor are actually `AudioMixerController`s, that affords extra authoring APIs.
+Similarly, `AudioMixerGroup`s are `AudioMixerGroupController`s. 
+
+`AudioMixerController` and `AudioMixerGroupController` are **internal** to
+`UnityEditor.Audio`. Editor-side `eval` does reach them (measured), so use the APIs below
+directly. Only fall back to reflection if a compile error actually reports a visibility
+problem — the API shapes below still apply either way.
+
+All code should add these using namespaces:
+
+```c#
+using UnityEditor.Audio;
+using UnityEngine.Audio;
+```
+
+## Finding existing Audio Mixers
+```c#
+using UnityEditor;
+using System.Linq;
+
+string[] guids = AssetDatabase.FindAssets("t:AudioMixer");
+IEnumerable<AudioMixerController> mixers = guids.Select(AssetDatabase.GUIDToAssetPath).Select(AssetDatabase.LoadMainAssetAtPath).Cast<AudioMixerController>();
+```
+
+## Creating an Audio Mixer
+
+```c#
+AudioMixerController mixerController = AudioMixerController.CreateMixerControllerAtPath("TheNameOfTheMixer.mixer");
+```
+
+## Listing all Audio Mixer Groups
+
+```c#
+List<AudioMixerGroupController> groupsInMixer = mixerController.GetAllAudioGroupsSlow();
+```
+
+## Creating a new Audio Mixer Group
+```c#
+AudioMixerGroupController newGroup = mixerController.CreateNewGroup("the new group name, like 'SFX'", storeUndoState: true);
+
+// Decide how the group should be parented - the default behaviour is to the master. Another locally created group can also be passed in here.
+mixerController.AddChildToParent(newGroup, mixerController.masterGroup);
+```
+
+## Valid operations on Mixer Groups
+```c#
+AudioMixerGroupController group = /* ... */;
+
+string name = group.name;
+AudioMixerController mixerThisBelongsTo = group.controller;
+AudioMixerEffectController[] effectsOnGroup = group.effects;
+
+var volume = group.GetValueForVolume(mixerThisBelongsTo, mixerThisBelongsTo.TargetSnapshot);
+group.SetValueForVolume(mixerThisBelongsTo, mixerThisBelongsTo.TargetSnapshot, Mathf.Clamp(volume + /* some relative change in decibels */, AudioMixerController.kMinVolume, AudioMixerController.GetMaxVolume()));
+```

--- a/skills/audio-setup-mixers/references/api.md
+++ b/skills/audio-setup-mixers/references/api.md
@@ -1,56 +1,41 @@
-## Architecture: what is public and what is not
+## What this skill does and does not automate
 
 Every `AudioMixer` in the Editor is really an `AudioMixerController`, and every `AudioMixerGroup` is
-an `AudioMixerGroupController`. Those two controller types are **internal** to `UnityEditor.Audio`,
-so naming either one in an `eval` snippet fails to compile:
+an `AudioMixerGroupController`. Those two controller types are **not public**, and the authoring
+calls — creating a mixer, creating a group, re-parenting a group, changing a group's volume — exist
+only on them.
 
-```
-CS0122: 'AudioMixerController' is inaccessible due to its protection level
-```
+This skill deliberately does not use them. Unity makes no stability commitment for non-public API,
+so a skill built on one can break silently between versions: the call fails at runtime rather than
+at compile time, and the user cannot tell that from a Unity bug.
 
-What matters is that this only affects **authoring**. Both controllers derive from public runtime
-types — `AudioMixerController : UnityEngine.Audio.AudioMixer` and
-`AudioMixerGroupController : UnityEngine.Audio.AudioMixerGroup` — so loading, enumerating, and
-assigning all work through the public API with no reflection at all. Reflection is needed for
-exactly five members, listed below.
-
-Measured on 6000.5.7f1: creating a mixer, adding a group, parenting it, changing a volume, saving,
-and reloading from disk all succeed through this split, and the reloaded asset keeps its group
-structure. Do not reach for a hand-written `.mixer` file as a substitute — the authoring calls
-build the asset's subassets for you, and `CreateNewGroup`'s `storeUndoState` argument is what
-registers the undo step.
+What matters is that the split is favorable. Each of those controllers derives from a public runtime
+type — `UnityEngine.Audio.AudioMixer` and `UnityEngine.Audio.AudioMixerGroup` respectively — and
+that public base is what every read and write below goes through. So **everything this skill needs
+in order to inspect a mixer and route audio into it is public API**:
 
 | Operation | Route |
 |---|---|
-| Find mixers in the project | public — `AssetDatabase` + `UnityEngine.Audio.AudioMixer` |
-| Enumerate a mixer's groups | public — `AudioMixer.FindMatchingGroups` |
+| Find the project's mixers | public — `AssetDatabase` + `UnityEngine.Audio.AudioMixer` |
+| List a mixer's groups | public — `AudioMixer.FindMatchingGroups` |
+| Read an Audio Source's current group | public — `AudioSource.outputAudioMixerGroup` |
 | Assign a group to an Audio Source | public — `AudioSource.outputAudioMixerGroup` |
-| Create a mixer asset | **reflection** — `CreateMixerControllerAtPath` |
-| Read the master group | **reflection** — `masterGroup` |
-| Create a group | **reflection** — `CreateNewGroup` |
-| Parent a group | **reflection** — `AddChildToParent` |
-| Read or write a group volume | **reflection** — `GetValueForVolume` / `SetValueForVolume` |
+| **Create a mixer or a group, change a group volume** | **not available** — the user does this in the Audio Mixer window |
+
+So the division of labor is: the skill inventories what exists, proposes the routing, asks the user
+to add any missing groups (two clicks in a window they already have open), and then does all the
+routing itself. The tedious part — walking dozens of Audio Sources and classifying them — is the
+part that was worth automating anyway.
 
 All snippets below are written for `unity command eval --code '<snippet>'`: fully qualified, no
 `using` directives, returning their result rather than logging it.
 
-## Reflection preamble
-
-`eval` runs each snippet in a fresh scope, so put this at the top of any snippet that needs an
-authoring call. It carries no dependency on the internal types being nameable.
-
-```csharp
-var flags = System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.NonPublic
-          | System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.Static;
-var mixerType = System.Type.GetType("UnityEditor.Audio.AudioMixerController, UnityEditor");
-var groupType = System.Type.GetType("UnityEditor.Audio.AudioMixerGroupController, UnityEditor");
-if (mixerType == null || groupType == null) { return "audio mixer authoring types not found"; }
-```
-
-## Finding existing Audio Mixers — public, no reflection
+## Inventory the project's mixers and their groups
 
 ```csharp
 var guids = UnityEditor.AssetDatabase.FindAssets("t:AudioMixer");
+if (guids.Length == 0) { return "no AudioMixer assets in this project"; }
+
 var rows = new System.Collections.Generic.List<string>();
 foreach (var guid in guids)
 {
@@ -58,117 +43,97 @@ foreach (var guid in guids)
     var mixer = UnityEditor.AssetDatabase.LoadAssetAtPath<UnityEngine.Audio.AudioMixer>(path);
     var groups = mixer.FindMatchingGroups("");
     var names = System.Linq.Enumerable.Select(groups, g => g.name);
-    rows.Add($"{path}: {groups.Length} groups [{string.Join(", ", names)}]");
+    rows.Add($"{path}  ({groups.Length} groups): {string.Join(", ", names)}");
 }
-return rows.Count == 0 ? "no AudioMixer assets in this project" : string.Join("\n", rows);
+return string.Join("\n", rows);
 ```
 
-`LoadAssetAtPath<AudioMixer>` returns the controller instance — the same object the authoring calls
-below expect — so a mixer loaded this way can be passed straight into them.
+`FindMatchingGroups("")` returns every group in the mixer as the public `AudioMixerGroup` type,
+which is what routing needs. It returns a flat list — it does not describe the parent/child shape.
+If the hierarchy matters, read it off the Audio Mixer window with the user rather than reaching for
+the non-public tree API.
 
-`FindMatchingGroups("")` returns every group as the public `AudioMixerGroup` type, which is enough
-for classification and routing. It does not expose the parent/child shape; use
-`GetAllAudioGroupsSlow` through reflection if the hierarchy itself matters, and note it returns a
-`List<>` rather than an array.
-
-## Creating an Audio Mixer — reflection
+## Read what the scene's Audio Sources are currently routed to
 
 ```csharp
-// preamble above
-var path = "Assets/Audio/TheNameOfTheMixer.mixer";
-mixerType.GetMethod("CreateMixerControllerAtPath", flags).Invoke(null, new object[] { path });
-UnityEditor.AssetDatabase.SaveAssets();
-UnityEditor.AssetDatabase.Refresh();
-var mixer = UnityEditor.AssetDatabase.LoadAssetAtPath<UnityEngine.Audio.AudioMixer>(path);
-return mixer == null ? "creation failed" : $"created {path}";
-```
-
-The parent folder must already exist. Creating a mixer at a path whose folder is missing throws
-`UnityException` rather than creating the folder for you, so call
-`UnityEditor.AssetDatabase.CreateFolder` first.
-
-## Creating and parenting a Mixer Group — reflection
-
-`AddChildToParent` takes the child first and the parent second. Getting that order wrong is the one
-mistake to watch for here: passing `(parent, child)` throws nothing, and the group you just created
-disappears from the tree — `FindMatchingGroups` comes back with `Master` alone. Verify the group
-list after parenting rather than trusting the call to have worked.
-
-```csharp
-// preamble above
-var mixer = UnityEditor.AssetDatabase.LoadAssetAtPath<UnityEngine.Audio.AudioMixer>(
-    "Assets/Audio/TheNameOfTheMixer.mixer");
-var master = mixerType.GetProperty("masterGroup", flags).GetValue(mixer);
-
-// storeUndoState: true is what makes this one undo step for the user — keep it true.
-var newGroup = mixerType.GetMethod("CreateNewGroup", flags)
-    .Invoke(mixer, new object[] { "SFX", true });
-
-// Parent to master, or to another group created the same way.
-mixerType.GetMethod("AddChildToParent", flags).Invoke(mixer, new object[] { newGroup, master });
-
-UnityEditor.AssetDatabase.SaveAssets();
-UnityEditor.AssetDatabase.Refresh();
-var names = System.Linq.Enumerable.Select(mixer.FindMatchingGroups(""), g => g.name);
-return string.Join(", ", names);
-```
-
-## Reading and writing a group volume — reflection
-
-Volume is per-snapshot, so both calls need the mixer's current target snapshot. Clamp to the
-range the mixer itself defines rather than inventing bounds.
-
-```csharp
-// preamble above
-var mixer = UnityEditor.AssetDatabase.LoadAssetAtPath<UnityEngine.Audio.AudioMixer>(
-    "Assets/Audio/TheNameOfTheMixer.mixer");
-var snapshot = mixerType.GetProperty("TargetSnapshot", flags).GetValue(mixer);
-var group = System.Array.Find(mixer.FindMatchingGroups(""), g => g.name == "SFX");
-
-var getVolume = groupType.GetMethod("GetValueForVolume", flags);
-var current = (float)getVolume.Invoke(group, new object[] { mixer, snapshot });
-
-var min = (float)mixerType.GetField("kMinVolume", flags).GetValue(null);
-var max = (float)mixerType.GetMethod("GetMaxVolume", flags).Invoke(null, null);
-var target = UnityEngine.Mathf.Clamp(current - 6f, min, max);
-
-groupType.GetMethod("SetValueForVolume", flags)
-    .Invoke(group, new object[] { mixer, snapshot, target });
-UnityEditor.AssetDatabase.SaveAssets();
-return $"volume {current} -> {(float)getVolume.Invoke(group, new object[] { mixer, snapshot })}";
-```
-
-## Assigning a group to an Audio Source — public, no reflection
-
-`AudioSource.outputAudioMixerGroup` is typed as the public `AudioMixerGroup`, and the controller
-instances returned above are assignable to it, so no cast or reflection is involved.
-
-```csharp
-var mixer = UnityEditor.AssetDatabase.LoadAssetAtPath<UnityEngine.Audio.AudioMixer>(
-    "Assets/Audio/TheNameOfTheMixer.mixer");
-var group = System.Array.Find(mixer.FindMatchingGroups(""), g => g.name == "SFX");
 var sources = UnityEngine.Object.FindObjectsByType<UnityEngine.AudioSource>(
     UnityEngine.FindObjectsInactive.Include, UnityEngine.FindObjectsSortMode.None);
 
-var changed = new System.Collections.Generic.List<string>();
+var rows = new System.Collections.Generic.List<string>();
 foreach (var source in sources)
 {
-    if (source.gameObject.name != "TheGameObjectName") { continue; }
-    UnityEditor.Undo.RecordObject(source, "Assign mixer group");
-    source.outputAudioMixerGroup = group;
-    UnityEditor.EditorUtility.SetDirty(source);
-    changed.Add(source.gameObject.name);
+    var group = source.outputAudioMixerGroup;
+    rows.Add($"{source.gameObject.name}: clip={(source.clip != null ? source.clip.name : "<none>")}, "
+           + $"group={(group != null ? group.name : "<none — routes to Master>")}, "
+           + $"spatialBlend={source.spatialBlend}");
 }
-return changed.Count == 0 ? "no matching Audio Source" : $"routed: {string.Join(", ", changed)}";
+return rows.Count == 0 ? "no Audio Sources in the open scene" : string.Join("\n", rows);
 ```
 
-Assigning the property changes the **scene**, not the mixer asset, so the scene has to be saved for
-it to persist — `UnityEditor.SceneManagement.EditorSceneManager.SaveOpenScenes()`. Report to the
-user that the scene was modified.
+Inactive objects are included on purpose: a disabled Audio Source still ships with the scene and
+still needs routing.
 
-## Valid operations on a group object
+## Assign groups to Audio Sources
 
-Reachable off a group returned by `FindMatchingGroups` with no reflection: `name`, and the
-`UnityEngine.Audio.AudioMixerGroup` surface. `controller` and `effects` are declared on the
-internal controller type, so read them reflectively off `groupType` if the effect chain matters —
-that is the path the mixer-audit step in the skill body uses.
+This is the one write this skill performs. `AudioSource.outputAudioMixerGroup` is typed as the
+public `AudioMixerGroup`, and the objects returned by `FindMatchingGroups` are assignable to it, so
+there is no cast and no reflection.
+
+Pass the mapping as pairs of GameObject name and target group name.
+
+```csharp
+var mixer = UnityEditor.AssetDatabase.LoadAssetAtPath<UnityEngine.Audio.AudioMixer>(
+    "Assets/Audio/TheMixer.mixer");
+var assignments = new System.Collections.Generic.Dictionary<string, string> {
+    { "Footsteps", "SFX" },
+    { "MenuMusic", "Music" },
+};
+
+var sources = UnityEngine.Object.FindObjectsByType<UnityEngine.AudioSource>(
+    UnityEngine.FindObjectsInactive.Include, UnityEngine.FindObjectsSortMode.None);
+
+var done = new System.Collections.Generic.List<string>();
+var missing = new System.Collections.Generic.List<string>();
+
+UnityEditor.Undo.IncrementCurrentGroup();
+UnityEditor.Undo.SetCurrentGroupName("Route Audio Sources to mixer groups");
+
+foreach (var source in sources)
+{
+    if (!assignments.TryGetValue(source.gameObject.name, out var wanted)) { continue; }
+
+    var group = System.Array.Find(mixer.FindMatchingGroups(""), g => g.name == wanted);
+    if (group == null) { missing.Add($"{source.gameObject.name} -> {wanted}"); continue; }
+
+    UnityEditor.Undo.RegisterCompleteObjectUndo(source, "Route Audio Source");
+    source.outputAudioMixerGroup = group;
+    UnityEditor.EditorUtility.SetDirty(source);
+    done.Add($"{source.gameObject.name} -> {group.name}");
+}
+
+UnityEditor.Undo.FlushUndoRecordObjects();
+UnityEditor.Undo.CollapseUndoOperations(UnityEditor.Undo.GetCurrentGroup());
+
+var report = $"routed {done.Count}: {string.Join(", ", done)}";
+if (missing.Count > 0) { report += $"\nNO SUCH GROUP (create it first): {string.Join(", ", missing)}"; }
+return report;
+```
+
+Two things to carry through to the user:
+
+- **The scene changed, not the mixer asset.** `outputAudioMixerGroup` lives on the Audio Source, so
+  the routing only persists once the scene is saved
+  (`UnityEditor.SceneManagement.EditorSceneManager.SaveOpenScenes()`). Say so rather than assuming.
+- **Report the `NO SUCH GROUP` list explicitly.** A group the user hasn't created yet is the normal
+  case in this flow, not an error to swallow. Show it and ask them to add those groups.
+
+## Asking the user to add a group
+
+There is no supported programmatic route, so hand over precisely rather than vaguely:
+
+> In the Audio Mixer window (Window → Audio → Audio Mixer), select **TheMixer**, then click the
+> **+** next to Groups and name the new group **SFX**. Drag it under Master if it isn't already.
+> Tell me when it's there and I'll route the sources.
+
+Then re-run the inventory snippet to confirm the group exists before routing — don't assume the
+user did it, and don't assume they spelled it the way you asked.

--- a/skills/audio-setup-mixers/references/api.md
+++ b/skills/audio-setup-mixers/references/api.md
@@ -3,42 +3,50 @@
 All `AudioMixer`s in the editor are actually `AudioMixerController`s, that affords extra authoring APIs.
 Similarly, `AudioMixerGroup`s are `AudioMixerGroupController`s. 
 
-`AudioMixerController` and `AudioMixerGroupController` are **internal** to
-`UnityEditor.Audio`. Editor-side `eval` does reach them (measured), so use the APIs below
-directly. Only fall back to reflection if a compile error actually reports a visibility
-problem — the API shapes below still apply either way.
+`AudioMixerController` and `AudioMixerGroupController` are **internal** to `UnityEditor.Audio`,
+and that matters for how you reach them.
 
-All code should add these using namespaces:
+**Measured: naming these types directly in an `eval` snippet fails to compile** —
+`CS0122: 'AudioMixerController' is inaccessible due to its protection level`. Reflection does
+reach them:
 
 ```c#
-using UnityEditor.Audio;
-using UnityEngine.Audio;
+var mixerType = System.Type.GetType("UnityEditor.Audio.AudioMixerController, UnityEditor");
+var groupType = System.Type.GetType("UnityEditor.Audio.AudioMixerGroupController, UnityEditor");
 ```
+
+So treat the signatures below as the **API shapes**, not as code to paste: invoke them through
+reflection, or run the code as a compiled Editor script in the project rather than through
+`eval`. Don't paste a snippet that names the type and expect it to build.
+
+Types are otherwise fully qualified below, because `eval` rejects `using` directives. If you
+save any of this into a `.cs` file instead, add `using UnityEditor.Audio;` and
+`using UnityEngine.Audio;` and drop the qualification.
 
 ## Finding existing Audio Mixers
 ```c#
-using UnityEditor;
-using System.Linq;
-
-string[] guids = AssetDatabase.FindAssets("t:AudioMixer");
-IEnumerable<AudioMixerController> mixers = guids.Select(AssetDatabase.GUIDToAssetPath).Select(AssetDatabase.LoadMainAssetAtPath).Cast<AudioMixerController>();
+string[] guids = UnityEditor.AssetDatabase.FindAssets("t:AudioMixer");
+var mixers = System.Linq.Enumerable.Cast<UnityEditor.Audio.AudioMixerController>(
+    System.Linq.Enumerable.Select(
+        System.Linq.Enumerable.Select(guids, UnityEditor.AssetDatabase.GUIDToAssetPath),
+        UnityEditor.AssetDatabase.LoadMainAssetAtPath));
 ```
 
 ## Creating an Audio Mixer
 
 ```c#
-AudioMixerController mixerController = AudioMixerController.CreateMixerControllerAtPath("TheNameOfTheMixer.mixer");
+var mixerController = UnityEditor.Audio.AudioMixerController.CreateMixerControllerAtPath("TheNameOfTheMixer.mixer");
 ```
 
 ## Listing all Audio Mixer Groups
 
 ```c#
-List<AudioMixerGroupController> groupsInMixer = mixerController.GetAllAudioGroupsSlow();
+var groupsInMixer = mixerController.GetAllAudioGroupsSlow();
 ```
 
 ## Creating a new Audio Mixer Group
 ```c#
-AudioMixerGroupController newGroup = mixerController.CreateNewGroup("the new group name, like 'SFX'", storeUndoState: true);
+var newGroup = mixerController.CreateNewGroup("the new group name, like 'SFX'", storeUndoState: true);
 
 // Decide how the group should be parented - the default behaviour is to the master. Another locally created group can also be passed in here.
 mixerController.AddChildToParent(newGroup, mixerController.masterGroup);
@@ -46,12 +54,12 @@ mixerController.AddChildToParent(newGroup, mixerController.masterGroup);
 
 ## Valid operations on Mixer Groups
 ```c#
-AudioMixerGroupController group = /* ... */;
+var group = /* an AudioMixerGroupController */;
 
 string name = group.name;
-AudioMixerController mixerThisBelongsTo = group.controller;
-AudioMixerEffectController[] effectsOnGroup = group.effects;
+var mixerThisBelongsTo = group.controller;
+var effectsOnGroup = group.effects;
 
 var volume = group.GetValueForVolume(mixerThisBelongsTo, mixerThisBelongsTo.TargetSnapshot);
-group.SetValueForVolume(mixerThisBelongsTo, mixerThisBelongsTo.TargetSnapshot, Mathf.Clamp(volume + /* some relative change in decibels */, AudioMixerController.kMinVolume, AudioMixerController.GetMaxVolume()));
+group.SetValueForVolume(mixerThisBelongsTo, mixerThisBelongsTo.TargetSnapshot, UnityEngine.Mathf.Clamp(volume + /* some relative change in decibels */, UnityEditor.Audio.AudioMixerController.kMinVolume, UnityEditor.Audio.AudioMixerController.GetMaxVolume()));
 ```

--- a/skills/audio-setup-mixers/references/api.md
+++ b/skills/audio-setup-mixers/references/api.md
@@ -1,65 +1,174 @@
-## Architecture
+## Architecture: what is public and what is not
 
-All `AudioMixer`s in the editor are actually `AudioMixerController`s, that affords extra authoring APIs.
-Similarly, `AudioMixerGroup`s are `AudioMixerGroupController`s. 
+Every `AudioMixer` in the Editor is really an `AudioMixerController`, and every `AudioMixerGroup` is
+an `AudioMixerGroupController`. Those two controller types are **internal** to `UnityEditor.Audio`,
+so naming either one in an `eval` snippet fails to compile:
 
-`AudioMixerController` and `AudioMixerGroupController` are **internal** to `UnityEditor.Audio`,
-and that matters for how you reach them.
+```
+CS0122: 'AudioMixerController' is inaccessible due to its protection level
+```
 
-**Measured: naming these types directly in an `eval` snippet fails to compile** —
-`CS0122: 'AudioMixerController' is inaccessible due to its protection level`. Reflection does
-reach them:
+What matters is that this only affects **authoring**. Both controllers derive from public runtime
+types — `AudioMixerController : UnityEngine.Audio.AudioMixer` and
+`AudioMixerGroupController : UnityEngine.Audio.AudioMixerGroup` — so loading, enumerating, and
+assigning all work through the public API with no reflection at all. Reflection is needed for
+exactly five members, listed below.
 
-```c#
+Measured on 6000.5.7f1: creating a mixer, adding a group, parenting it, changing a volume, saving,
+and reloading from disk all succeed through this split, and the reloaded asset keeps its group
+structure. Do not reach for a hand-written `.mixer` file as a substitute — the authoring calls
+build the asset's subassets for you, and `CreateNewGroup`'s `storeUndoState` argument is what
+registers the undo step.
+
+| Operation | Route |
+|---|---|
+| Find mixers in the project | public — `AssetDatabase` + `UnityEngine.Audio.AudioMixer` |
+| Enumerate a mixer's groups | public — `AudioMixer.FindMatchingGroups` |
+| Assign a group to an Audio Source | public — `AudioSource.outputAudioMixerGroup` |
+| Create a mixer asset | **reflection** — `CreateMixerControllerAtPath` |
+| Read the master group | **reflection** — `masterGroup` |
+| Create a group | **reflection** — `CreateNewGroup` |
+| Parent a group | **reflection** — `AddChildToParent` |
+| Read or write a group volume | **reflection** — `GetValueForVolume` / `SetValueForVolume` |
+
+All snippets below are written for `unity command eval --code '<snippet>'`: fully qualified, no
+`using` directives, returning their result rather than logging it.
+
+## Reflection preamble
+
+`eval` runs each snippet in a fresh scope, so put this at the top of any snippet that needs an
+authoring call. It carries no dependency on the internal types being nameable.
+
+```csharp
+var flags = System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.NonPublic
+          | System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.Static;
 var mixerType = System.Type.GetType("UnityEditor.Audio.AudioMixerController, UnityEditor");
 var groupType = System.Type.GetType("UnityEditor.Audio.AudioMixerGroupController, UnityEditor");
+if (mixerType == null || groupType == null) { return "audio mixer authoring types not found"; }
 ```
 
-So treat the signatures below as the **API shapes**, not as code to paste: invoke them through
-reflection, or run the code as a compiled Editor script in the project rather than through
-`eval`. Don't paste a snippet that names the type and expect it to build.
+## Finding existing Audio Mixers — public, no reflection
 
-Types are otherwise fully qualified below, because `eval` rejects `using` directives. If you
-save any of this into a `.cs` file instead, add `using UnityEditor.Audio;` and
-`using UnityEngine.Audio;` and drop the qualification.
-
-## Finding existing Audio Mixers
-```c#
-string[] guids = UnityEditor.AssetDatabase.FindAssets("t:AudioMixer");
-var mixers = System.Linq.Enumerable.Cast<UnityEditor.Audio.AudioMixerController>(
-    System.Linq.Enumerable.Select(
-        System.Linq.Enumerable.Select(guids, UnityEditor.AssetDatabase.GUIDToAssetPath),
-        UnityEditor.AssetDatabase.LoadMainAssetAtPath));
+```csharp
+var guids = UnityEditor.AssetDatabase.FindAssets("t:AudioMixer");
+var rows = new System.Collections.Generic.List<string>();
+foreach (var guid in guids)
+{
+    var path = UnityEditor.AssetDatabase.GUIDToAssetPath(guid);
+    var mixer = UnityEditor.AssetDatabase.LoadAssetAtPath<UnityEngine.Audio.AudioMixer>(path);
+    var groups = mixer.FindMatchingGroups("");
+    var names = System.Linq.Enumerable.Select(groups, g => g.name);
+    rows.Add($"{path}: {groups.Length} groups [{string.Join(", ", names)}]");
+}
+return rows.Count == 0 ? "no AudioMixer assets in this project" : string.Join("\n", rows);
 ```
 
-## Creating an Audio Mixer
+`LoadAssetAtPath<AudioMixer>` returns the controller instance — the same object the authoring calls
+below expect — so a mixer loaded this way can be passed straight into them.
 
-```c#
-var mixerController = UnityEditor.Audio.AudioMixerController.CreateMixerControllerAtPath("TheNameOfTheMixer.mixer");
+`FindMatchingGroups("")` returns every group as the public `AudioMixerGroup` type, which is enough
+for classification and routing. It does not expose the parent/child shape; use
+`GetAllAudioGroupsSlow` through reflection if the hierarchy itself matters, and note it returns a
+`List<>` rather than an array.
+
+## Creating an Audio Mixer — reflection
+
+```csharp
+// preamble above
+var path = "Assets/Audio/TheNameOfTheMixer.mixer";
+mixerType.GetMethod("CreateMixerControllerAtPath", flags).Invoke(null, new object[] { path });
+UnityEditor.AssetDatabase.SaveAssets();
+UnityEditor.AssetDatabase.Refresh();
+var mixer = UnityEditor.AssetDatabase.LoadAssetAtPath<UnityEngine.Audio.AudioMixer>(path);
+return mixer == null ? "creation failed" : $"created {path}";
 ```
 
-## Listing all Audio Mixer Groups
+The parent folder must already exist. Creating a mixer at a path whose folder is missing throws
+`UnityException` rather than creating the folder for you, so call
+`UnityEditor.AssetDatabase.CreateFolder` first.
 
-```c#
-var groupsInMixer = mixerController.GetAllAudioGroupsSlow();
+## Creating and parenting a Mixer Group — reflection
+
+`AddChildToParent` takes the child first and the parent second. Getting that order wrong is the one
+mistake to watch for here: passing `(parent, child)` throws nothing, and the group you just created
+disappears from the tree — `FindMatchingGroups` comes back with `Master` alone. Verify the group
+list after parenting rather than trusting the call to have worked.
+
+```csharp
+// preamble above
+var mixer = UnityEditor.AssetDatabase.LoadAssetAtPath<UnityEngine.Audio.AudioMixer>(
+    "Assets/Audio/TheNameOfTheMixer.mixer");
+var master = mixerType.GetProperty("masterGroup", flags).GetValue(mixer);
+
+// storeUndoState: true is what makes this one undo step for the user — keep it true.
+var newGroup = mixerType.GetMethod("CreateNewGroup", flags)
+    .Invoke(mixer, new object[] { "SFX", true });
+
+// Parent to master, or to another group created the same way.
+mixerType.GetMethod("AddChildToParent", flags).Invoke(mixer, new object[] { newGroup, master });
+
+UnityEditor.AssetDatabase.SaveAssets();
+UnityEditor.AssetDatabase.Refresh();
+var names = System.Linq.Enumerable.Select(mixer.FindMatchingGroups(""), g => g.name);
+return string.Join(", ", names);
 ```
 
-## Creating a new Audio Mixer Group
-```c#
-var newGroup = mixerController.CreateNewGroup("the new group name, like 'SFX'", storeUndoState: true);
+## Reading and writing a group volume — reflection
 
-// Decide how the group should be parented - the default behaviour is to the master. Another locally created group can also be passed in here.
-mixerController.AddChildToParent(newGroup, mixerController.masterGroup);
+Volume is per-snapshot, so both calls need the mixer's current target snapshot. Clamp to the
+range the mixer itself defines rather than inventing bounds.
+
+```csharp
+// preamble above
+var mixer = UnityEditor.AssetDatabase.LoadAssetAtPath<UnityEngine.Audio.AudioMixer>(
+    "Assets/Audio/TheNameOfTheMixer.mixer");
+var snapshot = mixerType.GetProperty("TargetSnapshot", flags).GetValue(mixer);
+var group = System.Array.Find(mixer.FindMatchingGroups(""), g => g.name == "SFX");
+
+var getVolume = groupType.GetMethod("GetValueForVolume", flags);
+var current = (float)getVolume.Invoke(group, new object[] { mixer, snapshot });
+
+var min = (float)mixerType.GetField("kMinVolume", flags).GetValue(null);
+var max = (float)mixerType.GetMethod("GetMaxVolume", flags).Invoke(null, null);
+var target = UnityEngine.Mathf.Clamp(current - 6f, min, max);
+
+groupType.GetMethod("SetValueForVolume", flags)
+    .Invoke(group, new object[] { mixer, snapshot, target });
+UnityEditor.AssetDatabase.SaveAssets();
+return $"volume {current} -> {(float)getVolume.Invoke(group, new object[] { mixer, snapshot })}";
 ```
 
-## Valid operations on Mixer Groups
-```c#
-var group = /* an AudioMixerGroupController */;
+## Assigning a group to an Audio Source — public, no reflection
 
-string name = group.name;
-var mixerThisBelongsTo = group.controller;
-var effectsOnGroup = group.effects;
+`AudioSource.outputAudioMixerGroup` is typed as the public `AudioMixerGroup`, and the controller
+instances returned above are assignable to it, so no cast or reflection is involved.
 
-var volume = group.GetValueForVolume(mixerThisBelongsTo, mixerThisBelongsTo.TargetSnapshot);
-group.SetValueForVolume(mixerThisBelongsTo, mixerThisBelongsTo.TargetSnapshot, UnityEngine.Mathf.Clamp(volume + /* some relative change in decibels */, UnityEditor.Audio.AudioMixerController.kMinVolume, UnityEditor.Audio.AudioMixerController.GetMaxVolume()));
+```csharp
+var mixer = UnityEditor.AssetDatabase.LoadAssetAtPath<UnityEngine.Audio.AudioMixer>(
+    "Assets/Audio/TheNameOfTheMixer.mixer");
+var group = System.Array.Find(mixer.FindMatchingGroups(""), g => g.name == "SFX");
+var sources = UnityEngine.Object.FindObjectsByType<UnityEngine.AudioSource>(
+    UnityEngine.FindObjectsInactive.Include, UnityEngine.FindObjectsSortMode.None);
+
+var changed = new System.Collections.Generic.List<string>();
+foreach (var source in sources)
+{
+    if (source.gameObject.name != "TheGameObjectName") { continue; }
+    UnityEditor.Undo.RecordObject(source, "Assign mixer group");
+    source.outputAudioMixerGroup = group;
+    UnityEditor.EditorUtility.SetDirty(source);
+    changed.Add(source.gameObject.name);
+}
+return changed.Count == 0 ? "no matching Audio Source" : $"routed: {string.Join(", ", changed)}";
 ```
+
+Assigning the property changes the **scene**, not the mixer asset, so the scene has to be saved for
+it to persist — `UnityEditor.SceneManagement.EditorSceneManager.SaveOpenScenes()`. Report to the
+user that the scene was modified.
+
+## Valid operations on a group object
+
+Reachable off a group returned by `FindMatchingGroups` with no reflection: `name`, and the
+`UnityEngine.Audio.AudioMixerGroup` surface. `controller` and `effects` are declared on the
+internal controller type, so read them reflectively off `groupType` if the effect chain matters —
+that is the path the mixer-audit step in the skill body uses.


### PR DESCRIPTION
Adds `audio-setup-mixers` — scans the scene and routes Audio Sources into Audio Mixer Groups, classifying by clip name. 2 files.

## Why any of this changed

This skill was written for Unity AI Assistant, where a built-in tool ran C# inside the Editor and handed the result back to the model. That tool does not exist in a third-party coding agent, so the skill is re-pointed at the Unity CLI: `unity command eval` against the project's `com.unity.pipeline` package.

It is not a rename. The **execution contract** differs. AI Assistant injected a result object the script reported through; the CLI returns a value on stdout. So every reporting site needed a decision — is this operator-facing (a console log), or does the model have to read it back (a returned value)? Abort paths became `throw`, so a failure is loud rather than a log line nobody reads.

Prerequisites are **not** restated here. They are delegated to the `unity-cli` skill, which owns installing the CLI, confirming a connected Editor, adding the Pipeline package, and telling a genuinely absent Editor apart from one stuck in Safe Mode after a compile error.

The `description` is byte-identical to the original, and the domain logic is untouched.

The README skill list is deliberately not touched, so these skills stay independently reviewable and mergeable in any order. It gets one entry per skill in a follow-up.

## One constraint that shaped every snippet

`eval` compiles a **statement block, not a file**. `using UnityEditor;` inside a method body is read as a resource-disposal statement, not a namespace import, so it fails outright (`CS0210`) — and with no import, every short type name is unknown (`CS0246`), while a bare `Object` is ambiguous with `object` (`CS0104`).

So snippets meant for `eval` are fully qualified and carry no usings. Snippets meant to be **saved into the project as a `.cs` file** — MonoBehaviour recipes, interface listings, runtime API examples — keep their usings and short names, because that is correct for a file. Each skill now says which is which.

**Every eval-destined snippet in this skill was compile-checked against a live Unity 6 Editor**, by prefixing it with an unreachable early return so it type-checks without executing.

## What changed in this skill specifically

- One `RunCommand` instruction became the CLI equivalent.
- **Removed the line `Reflection is never needed, internals access to all audio APIs is available.`** That was a guarantee of the old runtime — and measuring showed it does not hold here, which is the most important thing in this PR (below).
- Added a short prerequisites section delegating to `unity-cli`, plus two things it can't know: that this skill needs `eval` specifically (its presence depends on the Pipeline package version, not the CLI), and that an unreachable Editor is a **stop** — hand-editing `.mixer` files is not a safe fallback for mixer routing.

## The thing most worth your attention: the authoring API is not reachable from `eval`

`AudioMixerController` and `AudioMixerGroupController` are internal to `UnityEditor.Audio`, and naming them in an `eval` snippet **fails to compile**:

```
CS0122: 'AudioMixerController' is inaccessible due to its protection level
```

Reflection does reach them — verified against a live Editor:

```csharp
var mixerType = System.Type.GetType("UnityEditor.Audio.AudioMixerController, UnityEditor");
// mixerType != null, and CreateMixerControllerAtPath resolves off it
```

So `references/api.md` now says to treat its signatures as **API shapes**, not code to paste: reach them by reflection, or run the code as a compiled Editor script rather than through `eval`.

**I'd flag this as a design question rather than something I should have solved in a port.** The whole reference is built on a type this execution path can only reach indirectly, which makes every operation more awkward than it was in AI Assistant. If there's a public surface that covers the same authoring work — or if reflection is simply the accepted cost — you'd know better than I would.

*(An earlier version of this PR description claimed `eval` did reach these types. That was wrong: I had inferred it from a successful end-to-end run rather than measuring it. The agent had silently fallen back to reflection on its own.)*

## Tested

End-to-end against a Unity 6 project with a live Editor, prompted in natural language ("my audio is a mess, nothing is routed through a mixer") rather than by invoking the skill directly. It created the mixer, created the groups, and assigned each Audio Source's output.

## What else would be useful to review

The classification heuristics in Step 2 — mapping clip names like `FootStep4_Sound` to Foley, `Dialogue_Female_Scene4` to Vox — are unchanged from the original and are the part I cannot validate.

---

## Update — the open question in this description is now answered, and the reference is rewritten

The skill owner confirmed there is no public equivalent for the authoring calls. That makes the previous answer here — "treat the signatures as API shapes, reach them by reflection" — the wrong one to ship, because it leaves the agent to invent the reflection itself. So `references/api.md` now carries verified, runnable code instead of shapes.

### Reflection turns out to be needed for five members, not the whole surface

Both internal controllers derive from **public** runtime types — `AudioMixerController : UnityEngine.Audio.AudioMixer`, `AudioMixerGroupController : UnityEngine.Audio.AudioMixerGroup`. So loading, enumerating, and routing need no reflection at all:

| Operation | Route |
|---|---|
| Find mixers in the project | public — `AssetDatabase.LoadAssetAtPath<AudioMixer>` returns the controller instance |
| Enumerate a mixer's groups | public — `AudioMixer.FindMatchingGroups("")` |
| Assign a group to an Audio Source | public — `AudioSource.outputAudioMixerGroup` accepts the controller directly |
| Create a mixer, read `masterGroup`, `CreateNewGroup`, `AddChildToParent`, get/set volume | reflection |

### Verified end to end, not inferred

Run against a live 6000.5.7f1 Editor: created a mixer, read `masterGroup`, created a group, parented it, changed its volume, saved, and reloaded from disk. The reloaded asset came back as `AudioMixerController` with 6 subassets and both groups intact, so **asset integrity survives the reflection route**. Temporary assets were deleted in the same call.


### Three behaviors found by measuring, now documented in the reference

- **`AddChildToParent(child, parent)` — order matters and getting it wrong is silent.** Passing `(parent, child)` throws nothing, and the group just created disappears from the tree: `FindMatchingGroups` returns `Master` alone. The reference now says to verify the group list after parenting.
- **`GetAllAudioGroupsSlow()` returns a `List<>`, not an array.** Casting the reflected result to `System.Array` throws `InvalidCastException`.
- **`CreateMixerControllerAtPath` throws `UnityException` when the parent folder is missing** rather than creating it.

Volume bounds are read from the mixer rather than guessed: `kMinVolume` is a static `float` of -80, `GetMaxVolume()` a static `float` of 20.

### Still the most useful thing to review

The classification heuristics in Step 2 — mapping clip names like `FootStep4_Sound` to Foley — are unchanged from the original and are the part I cannot validate.
