### PR TITLE
feat: add the unity-scene-creator skill

### DIFF
--- a/skills/unity-scene-creator/SKILL.md
+++ b/skills/unity-scene-creator/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: unity-scene-creator
+description: Skill for creating and visually validating Unity scenes (2D/3D). Use this skill when the user wants to create a new Unity scene or setup a specific environment.
+modes: [agent, ask]
+---
+
+# Unity Scene Creator
+
+**Important:** When activated, read the reference files:
+- `references/common-issues.md` — Common mistakes to avoid
+
+## Instructions
+
+### Step 1: **Gather assets**
+  - Use `Find Project assets` tool to create an inventory of relevant assets.
+  - Prioritise folders called Prefabs (3D) or Sprites (2D). However, naming might be imperfect.
+  - If no relevant assets are found, generate them.
+
+### Step 2: **Create the Scene**
+  - Generate the C# script to build the requested 2D or 3D scene. Execute through the Editor with `eval`. Note: you will re-use this code in step 5.
+
+### Step 3: **Capture the Scene**
+  - 3D scenes: 
+      - Capture several angles of the Scene View — see [references/capturing-the-editor.md](references/capturing-the-editor.md). 
+      - FocusObjectIds: If you just placed objects A, B and C, use their IDs. Don't use parent objects (eg. pick building, not city). If unsure, use an empty array.
+      - For general view, use an empty array. 
+  - 2D scenes: a single straight-on Scene View capture is enough — see [references/capturing-the-editor.md](references/capturing-the-editor.md).
+  - This screenshot 1 shows the CURRENT state.
+
+### Step 4: **Validate the Scene**
+  - IMPORTANT: Analyse image carefully. Don't rush, as important visual info is easily ignored.
+  - Use the following checklist:
+    - Are all KEY OBJECTS present in the scene? 
+    - Is there any unintentional OVERLAPPING (e.g. trees on top of each other)?
+    - Is the SCALE realistic throughout (e.g. table bigger than a pizza)?
+    - Is the PLACEMENT correct? Check that objects are not sinking or floating in relation to the surface they should sit on, and that objects are inside their containers (sofa inside a house).
+  
+### Step 5: **Fix the scene (MAX 3 times)** 
+  - If anything does not pass validation, ALWAYS revisit and modify your C# script from step 2. DO NOT start from scratch as it is wasteful.
+  - DON'T analyse the screenshot again. It is OUTDATED after your fixes.
+  - Instead, when you are done with your fixes, repeat step 3 with new screenshot. 
+  - IMPORTANT: NEVER validate and fix more than three (3) times, even if unhappy with results. After 3 rounds, ask for user input. 
+
+### Step 6: **Finish and explain**
+  - Describe the outcome to user. 

--- a/skills/unity-scene-creator/references/capturing-the-editor.md
+++ b/skills/unity-scene-creator/references/capturing-the-editor.md
@@ -1,0 +1,66 @@
+# Capturing the Editor for visual checks
+
+There is no capture command in the Pipeline catalog. Run the capture as C# through `eval`, write
+a PNG, then **read that file** — reading an image is something the agent does natively, so the
+two-step version is equivalent to a single capture tool.
+
+Both variants below were verified against a live Unity 6 Editor.
+
+## Scene View
+
+```csharp
+var sv = UnityEditor.SceneView.lastActiveSceneView;
+if (sv == null) throw new System.Exception("No active SceneView to capture.");
+var cam = sv.camera;
+var rt = new UnityEngine.RenderTexture(1280, 720, 24);
+var prevTarget = cam.targetTexture; cam.targetTexture = rt; cam.Render(); cam.targetTexture = prevTarget;
+var prevActive = UnityEngine.RenderTexture.active; UnityEngine.RenderTexture.active = rt;
+var tex = new UnityEngine.Texture2D(1280, 720, UnityEngine.TextureFormat.RGB24, false);
+tex.ReadPixels(new UnityEngine.Rect(0, 0, 1280, 720), 0, 0); tex.Apply();
+UnityEngine.RenderTexture.active = prevActive;
+var path = System.IO.Path.Combine(System.IO.Path.GetTempPath(), "unity-sceneview.png");
+System.IO.File.WriteAllBytes(path, UnityEngine.ImageConversion.EncodeToPNG(tex));
+return path;
+```
+
+## Game camera
+
+Same shape, rendering `Camera.main` instead:
+
+```csharp
+var cam = UnityEngine.Camera.main;
+if (cam == null) throw new System.Exception("No Camera.main in the active scene.");
+var rt = new UnityEngine.RenderTexture(1280, 720, 24);
+var prevTarget = cam.targetTexture; cam.targetTexture = rt; cam.Render(); cam.targetTexture = prevTarget;
+var prevActive = UnityEngine.RenderTexture.active; UnityEngine.RenderTexture.active = rt;
+var tex = new UnityEngine.Texture2D(1280, 720, UnityEngine.TextureFormat.RGB24, false);
+tex.ReadPixels(new UnityEngine.Rect(0, 0, 1280, 720), 0, 0); tex.Apply();
+UnityEngine.RenderTexture.active = prevActive;
+var path = System.IO.Path.Combine(System.IO.Path.GetTempPath(), "unity-gameview.png");
+System.IO.File.WriteAllBytes(path, UnityEngine.ImageConversion.EncodeToPNG(tex));
+return path;
+```
+
+## Several angles
+
+Move the Scene View camera between captures and write a distinct filename each time. `sv.pivot`
+sets what it looks at, `sv.rotation` the direction, `sv.size` the distance; call `sv.Repaint()`
+after changing them, then capture as above.
+
+```csharp
+var sv = UnityEditor.SceneView.lastActiveSceneView;
+sv.pivot = new UnityEngine.Vector3(0, 0, 0);
+sv.rotation = UnityEngine.Quaternion.Euler(30, 45, 0);   // vary this per angle
+sv.size = 10f;
+sv.Repaint();
+```
+
+To frame specific objects rather than a fixed point, select them and use
+`UnityEditor.SceneView.FrameLastActiveSceneView()`, or set `sv.pivot` to the centre of their
+combined bounds.
+
+**Then read the returned path.** Write each capture to a distinct filename so a later capture
+doesn't get confused with an earlier one — comparing before and after a change is the whole point.
+
+Temp files are the default here rather than `Assets/`: a PNG written into the project becomes an
+imported asset the user then has to clean up.

--- a/skills/unity-scene-creator/references/common-issues.md
+++ b/skills/unity-scene-creator/references/common-issues.md
@@ -1,0 +1,23 @@
+# Common Scene Creation Issues
+
+## Exceeding 3 Capture-and-Fix Rounds
+
+- ALWAYS limit capture and fixing rounds to 3 (three). This improves user experience.
+- ALWAYS respect the limit even if you still see issues. 
+- WHY? Over iterating wastes user's time. They don't know how the scene will look like.
+
+## Regenerating C# Script Unnecessarily
+
+- If you notice issues in the scene, address them by MODIFYING the C# script you used to build the scene.
+- Recreating code and scene from scratch is wasteful.
+
+## Wrong Capture Tool
+
+- 3D scenes: capture several angles, not one. 
+- 2D scenes: one straight-on capture is enough.
+
+## Wrong Object Placement Accepted
+
+- When scene has many GameObjects, it is easy to ignore wrong placement in the visual validation step.
+- BAD: sofa SINKING through the floor. Houses OVERLAP each other. Player FLOATING above ground.
+- GOOD: check the position of each placed GameObject from the image, one by one.


### PR DESCRIPTION
Adds `unity-scene-creator` — builds a scene from a description, then captures and validates the result. 3 files.

## The interesting part: the capture tools turned out not to be a blocker

This skill was on my "cannot port" list, because it depends on capturing the Scene View to look at what it built, and the Pipeline catalog has no capture command. That verdict was wrong.

`eval` runs arbitrary C#, so the capture is just code — render the Scene View camera to a `RenderTexture`, read the pixels, encode a PNG, write it to a temp file, return the path. The agent then **reads that file**, which is something it does natively. AI Assistant's dedicated capture tool bundled those two steps; splitting them back apart costs one extra call and nothing else.

Verified against a live Unity 6 Editor — both variants produce a valid PNG that I could then open and inspect:

```
Scene View   → 10,573 bytes, 640x360 PNG
Game camera  → 81,203 bytes
```

The pattern is written up in `references/capturing-the-editor.md`, which is new.

## The one constraint that shapes the snippets

`eval` compiles a **statement block, not a file**. `using UnityEditor;` inside a method body is read as a resource-disposal statement rather than a namespace import, so it fails outright (`CS0210`) — and with no import, short type names are unknown (`CS0246`) and a bare `Object` is ambiguous with `object` (`CS0104`).

So snippets meant for `eval` are fully qualified and carry no usings. Snippets meant to be **saved into the project as a `.cs` file** keep their usings and short names, because that is correct for a file. **Every eval-destined snippet here was compile-checked against a live Unity 6 Editor**, by prefixing it with an unreachable early return so it type-checks without executing.

## What changed specifically

- `Unity.SceneView.CaptureMultiAngleSceneView` and `Unity.SceneView.Capture2DScene` are replaced by pointers to the capture reference. Multi-angle becomes explicit: move `sv.pivot` / `sv.rotation` / `sv.size`, call `sv.Repaint()`, capture again to a distinct filename.
- `Run Command` became "through the Editor with `eval`".
- `ReadSkillResource` — an AI Assistant tool for reading a skill's own files — was dropped; the agent reads relative paths directly.
- Captures go to temp files rather than `Assets/`, so a validation screenshot doesn't become an imported project asset the user has to clean up.
- `description` is byte-identical, and the scene-building workflow is untouched.

## What would be most useful to review

**Whether the multi-angle guidance is a good enough replacement.** The original just said "always use the multi-angle tool" and the tool decided the angles; now the skill has to choose them itself. I've described the mechanism (pivot, rotation, size, framing selected objects via `FrameLastActiveSceneView`) but not a specific set of angles, and you'd know better than I would whether particular viewpoints matter for catching the failure modes in `references/common-issues.md` — overlapping geometry, floating objects, wrong scale.
