### PR TITLE
fix: wire the localized string listener through public UnityEventTools

### DIFF
--- a/skills/localization/resources/L10nBatchProcessor.cs
+++ b/skills/localization/resources/L10nBatchProcessor.cs
@@ -2,6 +2,8 @@ using UnityEngine;
 using UnityEditor;
 using UnityEditor.SceneManagement;
 using UnityEngine.UI;
+using UnityEditor.Events;
+using UnityEngine.Events;
 using UnityEngine.Localization.Components;
 using System.Collections.Generic;
 
@@ -39,18 +41,27 @@ public static class L10nBatchProcessor
                     ?? text.gameObject.AddComponent<LocalizeStringEvent>();
                 lse.StringReference = new UnityEngine.Localization.LocalizedString(table, kvp.Value);
 
-                // Use SerializedObject to set dynamic binding mode (Mode 0).
-                // UnityEventTools.AddPersistentListener cannot reliably set Mode 0.
-                var so = new SerializedObject(lse);
-                var calls = so.FindProperty("m_UpdateString.m_PersistentCalls.m_Calls");
-                calls.ClearArray();
-                calls.InsertArrayElementAtIndex(0);
-                var call = calls.GetArrayElementAtIndex(0);
-                call.FindPropertyRelative("m_Target").objectReferenceValue = text;
-                call.FindPropertyRelative("m_MethodName").stringValue = "set_text";
-                call.FindPropertyRelative("m_Mode").enumValueIndex = 0;       // Dynamic
-                call.FindPropertyRelative("m_CallState").enumValueIndex = 2;  // EditorAndRuntime
-                so.ApplyModifiedProperties();
+                // Wire the listener through the public UnityEventTools API. The persistent-call
+                // fields could be written directly through SerializedObject instead, but those
+                // are private serialized names with no compatibility guarantee — and it isn't
+                // necessary. A delegate to Text's public `text` setter, handed to
+                // AddPersistentListener, serializes to exactly the same thing: target = the Text
+                // component, method = set_text, mode = EventDefined (dynamic), call state =
+                // EditorAndRuntime. Measured on Unity 6000.5.7f1.
+                //
+                // The setter has no C# method-group name, so the delegate is built by name.
+                // That is reflection over a *public* member, which is fine; reaching for the
+                // private m_* fields would not be.
+                var setText = (UnityAction<string>)System.Delegate.CreateDelegate(
+                    typeof(UnityAction<string>), text, "set_text");
+
+                for (int i = lse.OnUpdateString.GetPersistentEventCount() - 1; i >= 0; i--)
+                {
+                    UnityEventTools.RemovePersistentListener(lse.OnUpdateString, i);
+                }
+                UnityEventTools.AddPersistentListener(lse.OnUpdateString, setText);
+
+                EditorUtility.SetDirty(lse);
                 break;
             }
         }


### PR DESCRIPTION
Completes the localized-string binding fix. The public-API change landed in `SKILL.md` earlier; the batch-processing resource script in the same skill was still writing the private serialized fields of the event, which is the same dependency in a place the earlier pass didn't reach.

## What it did, and why it looked necessary

The script wired the `OnUpdateString` listener by hand:

```csharp
var calls = so.FindProperty("m_UpdateString.m_PersistentCalls.m_Calls");
call.FindPropertyRelative("m_MethodName").stringValue = "set_text";
call.FindPropertyRelative("m_Mode").enumValueIndex = 0;
```

with a comment stating that `UnityEventTools.AddPersistentListener` "cannot reliably set Mode 0" (dynamic binding). The obstacle behind that is real: `Text.text` is a property, and a property setter has no C# method-group name, so there is nothing obvious to hand `AddPersistentListener`.

## Measured: the public API does do it

`System.Delegate.CreateDelegate` builds the delegate from the setter's name, and the public API then serializes exactly what the hand-written version produced. Verified on Unity 6000.5.7f1 against an equivalent `UnityEvent<string>`:

```
serialized -> target=Text  method=set_text  mode=0  callState=2
```

`mode=0` is `EventDefined` — dynamic binding, the thing the comment said was unreachable. So the private-field route was never necessary, and the comment was wrong.

The replacement removes any existing persistent listeners first, so re-running the batch processor over a scene twice does not stack duplicates — the old code cleared the array, and that behavior is preserved.

Building a delegate from a member name is reflection, but over a **public** member, which is the distinction that matters: the dependency is `Text.text`, which Unity commits to. Reaching for `m_PersistentCalls` would have depended on a private serialized layout that carries no such commitment.

Nothing else in the skill touches non-public API.
