### PR TITLE
feat: add new-unity-project and unity-package-management

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,8 @@ explicitly instead of describing the task.
 
 | Skill | |
 |---|---|
+| `new-unity-project` | Guided flow from an idea to a running, version-controlled project: gathers concept, platforms and monetization, then delegates setup |
+| `unity-package-management` | Add, remove, upgrade or discover Unity (UPM) packages, and choose packages by genre, platform or monetization |
 | `2d-pixel-perfect` | Pixel-perfect 2D rendering — pipeline detection, filter modes, camera setup, reference resolution |
 | `manage-sprite-atlas` | Sprite atlases via a prebuild pipeline — master and variant atlases, packing and platform settings |
 | `tilemap-palette-create` | Tile Palette assets for rectangular, hexagonal, or isometric grids |
@@ -111,6 +113,7 @@ explicitly instead of describing the task.
 | `ui-uitk` | UI Toolkit — UXML and USS authoring, flex layout, custom elements, Painter2D, runtime binding |
 | `ui-ugui` | uGUI — Canvas hierarchies, RectTransform anchoring, Layout Groups, prefab UI |
 | `ui-imgui` | IMGUI editor tooling — EditorWindows, custom Inspectors, PropertyDrawers |
+| `optimize-web` | Shrink and speed up WebGL/WebGPU builds — compression, stripping, memory, frame rate, KTX textures |
 | `optimize-text-mesh-pro` | TextMeshPro font stacks, dynamic atlases, SDF quality, CJK fallback, text memory |
 | `localization` | Unity Localization — locales, String and Asset Tables, CJK fonts, Addressables |
 

--- a/skills/new-unity-project/SKILL.md
+++ b/skills/new-unity-project/SKILL.md
@@ -1,0 +1,179 @@
+---
+name: new-unity-project
+description: Use when starting a brand-new Unity game or project from scratch — "make/start/create a new game", "bootstrap a Unity project", "I want to build a <genre> game", "scaffold/prototype a game", game jam, greenfield, blank project, project setup. A guided flow that gathers the concept, target platforms, and monetization, installs the Editor in the background while it asks, then creates the project and source control and installs packages — delegating the mechanics to the unity-cli and unity-package-management skills and handing off monetization to the dedicated skills. Does not scaffold gameplay code.
+allowed-tools:
+  - Bash
+  - Read
+  - Write
+  - Edit
+  - AskUserQuestion
+---
+
+# New Unity Project
+
+A guided flow from an idea to a running, version-controlled Unity project. This skill owns the
+**flow** — the questions, their ordering, running slow installs in the background while you ask,
+and the handoffs. It deliberately does **not** re-document commands; it delegates the mechanics
+to other skills.
+
+**Delegates to (read these for the actual commands — don't reinvent them):**
+- **`unity-cli`** — CLI install, auth/license, Editor install, project creation, source control,
+  opening the project. Its "Bootstrap a new project from scratch" workflow is the backbone here.
+- **`unity-package-management`** — installing packages via the C# PackageManager Client API, and
+  choosing packages by genre / platform / monetization.
+- **`implement-in-app-purchases`**, **`levelplay-unity-integration`**, **`build-live-game`** —
+  monetization / backend *integration* (invoked at the end).
+
+**Work one step at a time.** Ask only the current step's questions and wait for the user before
+moving on — platform and monetization answers change what you install, so don't gather everything
+up front or scaffold before they're settled.
+
+## The flow — and where the parallelism is
+
+1. **Concept** — what they're building.
+2. **Platforms & monetization** — then, as soon as platforms are known, **kick off the Editor
+   install in the background** (it takes minutes) and keep talking.
+3. **(joins)** Editor + platform modules finish installing.
+4. **Project + source control** — create from a matching template; init git.
+5. **Packages** — install via the C# Client API.
+6. **Save & first commit.**
+7. **Hand off** monetization / backend.
+
+The whole point of a guided flow over a raw recipe: the multi-minute Editor install overlaps the
+minutes the user spends answering concept questions, so setup feels instant.
+
+## Step 1 — Concept
+
+Use `AskUserQuestion` so the user can pick fast, but let them answer freely too. Cover:
+
+- **Genre / core loop** — platformer, top-down shooter, puzzle, idle, RPG, racing, card, tower
+  defense, sim, hyper-casual, first-person, etc.
+- **Dimension & look** — 2D or 3D; art style (pixel, low-poly, stylized, realistic, UI-only).
+- **Gameplay** — the one-sentence "what the player does moment to moment."
+- **Scope** — single-screen prototype vs. multi-scene game; single-player or multiplayer.
+
+Also settle on a **project name**. Write a 2–4 line **project brief**, read it back to confirm.
+The brief drives template choice (Step 4) and packages (Step 5).
+
+## Step 2 — Platforms & monetization, then start installing
+
+Two decisions, because both change what you install:
+
+- **Target platforms** (multi-select): Desktop (Win/macOS/Linux), Mobile (iOS/Android), WebGL,
+  Console. These map to Editor **modules** (Step 3) and argue for leaner packages on mobile/WebGL.
+- **Monetization**: none / premium / in-app purchases / ads / mix. This only decides which
+  handoff skill you invoke in Step 7 — don't integrate it now.
+
+Confirm the Editor version to use (**default: latest LTS** — see `unity-cli` for the LTS vs. Tech
+vs. beta trade-off). Ask this *now*, before kicking off the install, so you don't install the
+wrong one.
+
+Then confirm prerequisites and **launch the Editor install as a background task** so it runs while
+you continue. See the `unity-cli` skill for exact syntax, module names per platform, and auth /
+license setup:
+
+```bash
+unity --version
+unity auth status --format json      # if signed out:  unity auth login
+unity license status --format json   # if none active: unity license activate
+
+# Start in the BACKGROUND, then go straight back to the conversation. Module names per platform
+# (android / ios / webgl / …) are in the unity-cli skill.
+unity install lts --module <platform-modules> --yes --accept-eula
+```
+
+Run that install as a **background task** (don't block on it). If you have nothing left to ask,
+it's fine to just wait — the parallelism only helps when there's a conversation to overlap.
+
+## Step 3 — Join: Editor ready
+
+Before creating the project, confirm the background install finished:
+
+```bash
+unity editors --installed --format json
+```
+
+If it failed, surface the error (see `unity-cli` troubleshooting) and stop — nothing downstream
+works without an Editor.
+
+## Step 4 — Create the project + source control
+
+Follow the **`unity-cli`** "Bootstrap a new project from scratch" workflow verbatim:
+
+- List the **real** template ids the Editor offers (`unity templates list`) and pick one matching
+  2D/3D and render pipeline from the brief — don't guess ids.
+- Create with `unity projects create "<Name>" --path <dir> --editor-version <v> --template <id>`.
+- Set up source control — **ask the user which they want**, don't assume: Git (GitHub / GitLab;
+  add `--git-lfs` for asset-heavy games) or **Unity Version Control** (`--vcs uvcs`, which handles
+  large binary assets natively — no LFS), or a purely local `git init` + Unity `.gitignore`.
+  Publish in one step with `unity projects create --vcs … --git-token-stdin --no-initial-commit`
+  (tokens on stdin). Pass **`--no-initial-commit`** so the CLI doesn't commit the bare project
+  before packages and `.meta` files exist — you make the real first commit/check-in in Step 6.
+  See the `unity-cli` workflow for exact flags.
+
+## Step 5 — Packages
+
+Map the brief to a concrete package list and install it via the **`unity-package-management`**
+skill (C# PackageManager Client API — **never** hand-edit `manifest.json`). Read that skill for
+the genre/platform/monetization → package mapping, the installer script, and the `-quit` gotcha.
+Read the final list back to the user before installing; verify `manifest.json` afterward.
+
+## Step 6 — Save & first commit
+
+Open the project once so Unity imports the assets and generates every `.meta` file, then make
+the first commit **with whichever VCS you set up in Step 4**:
+
+```bash
+unity open "<project-path>"     # imports + generates .meta; for headless/CI use the
+                                # "Import & save headlessly" method in unity-package-management
+```
+
+- **Git (GitHub / GitLab / local):**
+  ```bash
+  cd "<project-path>"
+  git add -A
+  git status                    # Library/ Temp/ obj/ Build/ must NOT be staged
+  git commit -m "Initial Unity project: <Name>"
+  ```
+  Every `.cs`/asset must be committed together with its `.meta`.
+- **Unity Version Control (UVCS):** check in through your UVCS client/workspace (created during
+  Step 4) — there's no `git` step. Generated folders are still excluded by the ignore rules.
+
+If you published via `--vcs` in Step 4 **without** `--no-initial-commit`, the CLI already made an
+initial commit of the bare project — add a follow-up commit here rather than double-committing.
+
+## Step 7 — Hand off
+
+Based on Step 2 monetization, invoke the matching skill for the actual integration:
+- IAP → **implement-in-app-purchases**
+- Ads → **levelplay-unity-integration**
+- Accounts / cloud save / economy / remote config / leaderboards → **build-live-game**
+
+Report the project path, Editor version, installed packages, and next steps.
+
+## Scope — what this skill does NOT do
+
+- **No gameplay scaffolding.** It gets you to a running, empty-but-wired project; building the
+  actual game (scenes, controllers, art) is the next conversation — iterate there with the Editor
+  via the `unity-cli` MCP server and the Package Manager. Generic genre skeletons tend to produce
+  throwaway mocked primitives, so this skill intentionally stops at a clean starting point.
+- **No command reference.** Syntax lives in `unity-cli` / `unity-package-management`.
+
+## Checklist
+
+- [ ] Concept brief captured and confirmed (genre, look, gameplay, scope, name)
+- [ ] Platforms + monetization recorded; Editor version chosen
+- [ ] Editor + platform modules installed (started in the background during Step 2)
+- [ ] Project created from a matching template; git initialized with a Unity `.gitignore`
+- [ ] Packages installed via the C# Client API; `manifest.json` verified
+- [ ] Project opened/saved so `.meta` files exist; first commit made; `Library/` excluded
+- [ ] Handed off to the monetization/backend skill if applicable
+
+## Common mistakes
+
+- **Blocking on the Editor install** instead of backgrounding it while you ask questions.
+- **Installing the wrong Editor** because the version wasn't confirmed before the background install.
+- **Gathering all questions up front** — platform/monetization answers change the modules and packages.
+- **Hand-editing `manifest.json`** instead of using the Client API (see `unity-package-management`).
+- **Committing `Library/`/`Temp/`/`obj/`/`Build/`**, or scripts without their `.meta` files.
+- **Missing Editor modules** — a mobile target needs `android`/`ios`; WebGL needs `webgl`.

--- a/skills/unity-package-management/SKILL.md
+++ b/skills/unity-package-management/SKILL.md
@@ -1,0 +1,304 @@
+---
+name: unity-package-management
+description: Use when adding, removing, upgrading, or discovering Unity (UPM) packages programmatically from outside the Editor — headless or CI package installs via the C# UnityEditor.PackageManager.Client API, verifying package ids/versions against the Unity registry, or choosing which packages a game needs by genre, platform, and monetization. The Unity CLI does not manage UPM packages, so this skill covers that gap. Triggers on "install a Unity package", "add com.unity.*", "set up packages headless/CI", "which packages for a <genre> game".
+allowed-tools:
+  - Bash
+  - Read
+  - Write
+  - Edit
+---
+
+# Unity Package Management (headless, via the C# Client API)
+
+Add, remove, upgrade, and discover UPM (Unity Package Manager) packages programmatically with
+`UnityEditor.PackageManager.Client`, driven headless from the terminal or CI. Do **not**
+hand-edit `Packages/manifest.json` — the Client API resolves dependencies and compatible
+versions correctly, whereas manual edits routinely break resolution.
+
+This complements the **`unity-cli`** skill (editor install, project creation, build/test): the
+CLI has **no** package-management command, so all package work goes through the Editor's C# API.
+
+## When to use
+
+- Add / remove / upgrade one or more packages in an existing or freshly-created project.
+- Set up a project's packages non-interactively in CI.
+- Verify a package id exists, or find its available versions, before depending on it.
+- Decide which packages a game actually needs — see
+  [references/select-packages.md](references/select-packages.md).
+
+## Choosing what to install
+
+Install what the project actually needs, not everything; prefer packages the chosen template
+already provides (URP templates already include the render pipeline, Input System, etc.). The
+genre / look / platform / monetization → package mapping, plus how to search the registry, is
+in [references/select-packages.md](references/select-packages.md). Produce a **deduplicated
+list of package ids** and read it back to the user before installing.
+
+## The `-quit` problem — why NOT `unity run` for installs
+
+`Client.Add` / `Client.AddAndRemove` are **asynchronous**: they return a `Request` that only
+completes on later `EditorApplication.update` ticks (the UPM child process marshals its result
+back on the Editor's main-loop pump, so a blocking `while (!req.IsCompleted)` busy-wait
+deadlocks it). The Editor must **stay alive** after `-executeMethod` returns, until the request
+finishes.
+
+`unity run` **cannot** be used for the installer: it always injects `-quit` (see the reserved
+flags in the **`unity-cli`** skill). With `-quit`, the Editor quits the instant the method
+returns — before UPM resolves — so packages never install and the callback never runs.
+
+**Solution:** launch the **Editor binary directly** in `-batchmode` **without** `-quit`. The
+Editor stays alive, `EditorApplication.update` keeps ticking, the poll callback runs, and it
+calls `EditorApplication.Exit(code)` itself when done — which both quits and sets the process
+exit code.
+
+## The installer script
+
+Write this to `Assets/Editor/ProjectBootstrap/PackageInstaller.cs`. It must live under an
+`Editor/` folder (or an Editor-only assembly) because it uses `UnityEditor`.
+
+```csharp
+using System.Linq;
+using UnityEditor;
+using UnityEditor.PackageManager;
+using UnityEditor.PackageManager.Requests;
+using UnityEngine;
+
+namespace ProjectBootstrap
+{
+    // Installs (and optionally removes) a fixed set of packages via the PackageManager
+    // Client API, headless-safe.
+    public static class PackageInstaller
+    {
+        // EDIT this list to match the package selection (see references/select-packages.md).
+        static readonly string[] PackagesToAdd =
+        {
+            "com.unity.inputsystem",
+            "com.unity.cinemachine",
+            "com.unity.render-pipelines.universal",
+            // "com.unity.package@1.2.3"  // pin a version with @ when a minimum is required
+        };
+
+        // Optionally drop packages in the same resolution pass (e.g. a template default you don't want).
+        static readonly string[] PackagesToRemove = { };
+
+        const double TimeoutSeconds = 600; // UPM resolution + downloads can be slow
+
+        static AddAndRemoveRequest _request;
+        static double _deadline;
+
+        // Invoke with: -executeMethod ProjectBootstrap.PackageInstaller.Install  (NO -quit)
+        public static void Install()
+        {
+            if (PackagesToAdd.Length == 0 && PackagesToRemove.Length == 0)
+            {
+                Debug.Log("[PackageInstaller] Nothing to do.");
+                EditorApplication.Exit(0);
+                return;
+            }
+
+            Debug.Log($"[PackageInstaller] Adding: {string.Join(", ", PackagesToAdd)}");
+            _request = Client.AddAndRemove(packagesToAdd: PackagesToAdd, packagesToRemove: PackagesToRemove);
+            _deadline = EditorApplication.timeSinceStartup + TimeoutSeconds;
+            EditorApplication.update += Poll;
+        }
+
+        static void Poll()
+        {
+            if (_request == null) return;
+
+            if (!_request.IsCompleted)
+            {
+                if (EditorApplication.timeSinceStartup > _deadline)
+                {
+                    EditorApplication.update -= Poll;
+                    Debug.LogError("[PackageInstaller] Timed out waiting for UPM.");
+                    EditorApplication.Exit(2);
+                }
+                return;
+            }
+
+            EditorApplication.update -= Poll;
+
+            if (_request.Status == StatusCode.Success)
+            {
+                var names = _request.Result.Select(p => $"{p.name}@{p.version}");
+                Debug.Log($"[PackageInstaller] Resolved: {string.Join(", ", names)}");
+                EditorApplication.Exit(0);
+            }
+            else
+            {
+                Debug.LogError($"[PackageInstaller] Failed: {_request.Error?.message}");
+                EditorApplication.Exit(1);
+            }
+        }
+    }
+}
+```
+
+`AddAndRemove` installs the whole set in a single UPM resolution pass — faster and less
+error-prone than one `Client.Add` per package.
+
+**Add / remove / upgrade with one script:**
+- **Add**: list the id in `PackagesToAdd`.
+- **Remove**: list the id in `PackagesToRemove`.
+- **Upgrade / pin**: add the id with `@<version>` (e.g. `com.unity.cinemachine@2.9.7`). Without
+  a version, resolution picks the latest compatible release.
+
+## Discovering / verifying packages
+
+To confirm an id exists or list its versions before adding it, search the registry. The
+in-Editor `Client.SearchAll()` / `Client.Search("<id>")` calls are also async, so they use the
+**same poll-and-`Exit` pattern and the same headless run** as the installer. Write
+`Assets/Editor/ProjectBootstrap/PackageSearch.cs`:
+
+```csharp
+using System.Linq;
+using UnityEditor;
+using UnityEditor.PackageManager;
+using UnityEditor.PackageManager.Requests;
+using UnityEngine;
+
+namespace ProjectBootstrap
+{
+    public static class PackageSearch
+    {
+        const double TimeoutSeconds = 120;
+        static SearchRequest _request;
+        static double _deadline;
+
+        // Invoke with: -executeMethod ProjectBootstrap.PackageSearch.SearchAll  (NO -quit)
+        public static void SearchAll()
+        {
+            _request = Client.SearchAll();                 // or Client.Search("com.unity.cinemachine")
+            _deadline = EditorApplication.timeSinceStartup + TimeoutSeconds;
+            EditorApplication.update += Poll;
+        }
+
+        static void Poll()
+        {
+            if (_request == null) return;
+            if (!_request.IsCompleted)
+            {
+                if (EditorApplication.timeSinceStartup > _deadline)
+                {
+                    EditorApplication.update -= Poll;
+                    Debug.LogError("[PackageSearch] Timed out.");
+                    EditorApplication.Exit(2);
+                }
+                return;
+            }
+            EditorApplication.update -= Poll;
+
+            if (_request.Status == StatusCode.Success)
+            {
+                foreach (var p in _request.Result.OrderBy(p => p.name))
+                    Debug.Log($"[PackageSearch] {p.name}@{p.versions.latestCompatible}  {p.displayName}");
+                Debug.Log($"[PackageSearch] {_request.Result.Length} packages found.");
+                EditorApplication.Exit(0);
+            }
+            else
+            {
+                Debug.LogError($"[PackageSearch] Failed: {_request.Error?.message}");
+                EditorApplication.Exit(1);
+            }
+        }
+    }
+}
+```
+
+`_request.Result` is a `PackageInfo[]`; each entry exposes `name`, `displayName`, `description`,
+and `versions` (`.latest`, `.latestCompatible`, `.all`). For a terminal-only check without the
+Editor (a **known** id, not free-text search), query the registry directly — see
+[references/select-packages.md](references/select-packages.md#discovering-and-verifying-packages).
+
+## Run it headless (direct Editor invocation, no `-quit`)
+
+Resolve the Editor binary from the version, then run it in batch mode. The script owns quitting
+via `EditorApplication.Exit`, so do **not** pass `-quit`:
+
+```bash
+VERSION="<version>"          # e.g. 6000.0.47f1 (or an installed version)
+PROJECT="<project-path>"
+METHOD="ProjectBootstrap.PackageInstaller.Install"   # or ...PackageSearch.SearchAll
+
+# Install directory of that editor (Hub layout), via the unity CLI
+ED=$(unity editors path "$VERSION" --format json | python3 -c "import sys,json;print(json.load(sys.stdin)['data']['path'])")
+
+# Resolve the executable per-OS (handles both "dir containing Unity.app" and the ".app" itself)
+case "$(uname)" in
+  Darwin) if [ -d "$ED/Unity.app" ]; then UNITY_BIN="$ED/Unity.app/Contents/MacOS/Unity";
+          elif [[ "$ED" == *.app ]]; then UNITY_BIN="$ED/Contents/MacOS/Unity";
+          else UNITY_BIN="$ED/Unity"; fi ;;
+  Linux)  UNITY_BIN="$ED/Unity" ;;
+  *)      UNITY_BIN="$ED/Unity.exe" ;;   # Windows (Git Bash / MSYS); use Unity.exe in PowerShell
+esac
+
+"$UNITY_BIN" -batchmode -projectPath "$PROJECT" -executeMethod "$METHOD" -logFile -
+echo "Exit code: $?"   # 0 = success, 1 = UPM error, 2 = timeout
+```
+
+`-logFile -` streams the Editor log (including the `[PackageInstaller]` / `[PackageSearch]`
+lines) to stdout so you can watch resolution progress and read any UPM error. If
+`unity editors path` output shape differs on your build, get the directory from
+`unity editors --installed --format json` instead.
+
+## Verify
+
+```bash
+# Every requested id should appear as a dependency
+cat "<project-path>/Packages/manifest.json"
+```
+
+Confirm the run exited `0` and each package from the list is present in `manifest.json`. If a
+package fails to resolve, `_request.Error.message` is logged; read it and check the id/version
+against the registry. The Editor's own log (including the `[PackageInstaller]` lines) is the
+stdout you streamed with `-logFile -` above — read it there, not via `unity logs` (which shows
+the CLI's own log, not the Editor's).
+
+## Import & save headlessly (generate `.meta` files)
+
+After a script or tool writes new `.cs`/asset files, Unity must **import** them so it generates
+the `.meta` file each asset needs — and every `.cs`/asset MUST be committed together with its
+`.meta`. Merely opening the project once (`unity open "<project-path>"`) imports and generates
+them; use this method when you need it **headless** (in a script or CI).
+
+Unlike the package installer, this is **synchronous** — it finishes before returning — so it's
+safe to run via `unity run` (its injected `-quit` is harmless; the method also calls
+`EditorApplication.Exit` for a clean exit code). Write
+`Assets/Editor/ProjectBootstrap/ProjectSaver.cs`:
+
+```csharp
+using UnityEditor;
+using UnityEngine;
+
+namespace ProjectBootstrap
+{
+    public static class ProjectSaver
+    {
+        // Invoke with: -executeMethod ProjectBootstrap.ProjectSaver.SaveAll
+        public static void SaveAll()
+        {
+            AssetDatabase.Refresh(ImportAssetOptions.ForceUpdate);
+            AssetDatabase.SaveAssets();
+            Debug.Log("[ProjectSaver] Assets imported and saved.");
+            EditorApplication.Exit(0);
+        }
+    }
+}
+```
+
+```bash
+unity run "<project-path>" --editor-version <version> \
+  -- -executeMethod ProjectBootstrap.ProjectSaver.SaveAll
+```
+
+## Notes
+
+- These editor scripts are a bootstrap convenience. Leave them in
+  `Assets/Editor/ProjectBootstrap/` (they do nothing unless invoked) or delete them after
+  setup — your call; mention it to the user.
+- All scripts live under `Editor/` because they use `UnityEditor`; they never ship in a build.
+- Monetization / backend packages (`com.unity.purchasing`, `com.unity.services.levelplay`, the
+  UGS packages) install through this same mechanism, but do the actual **integration** via the
+  dedicated skills: **implement-in-app-purchases**, **levelplay-unity-integration**,
+  **build-live-game**.

--- a/skills/unity-package-management/references/select-packages.md
+++ b/skills/unity-package-management/references/select-packages.md
@@ -1,0 +1,108 @@
+# Selecting packages
+
+Turn a game concept — genre, look, target platforms, monetization — into a concrete package
+list, then install it via the C# PackageManager Client API (see the main `SKILL.md`).
+
+**Principle:** install what the concept actually needs, not everything. A hyper-casual 2D
+prototype needs far less than a 3D multiplayer RPG. Prefer packages already provided by the
+chosen template (URP templates already include the render pipeline, Input System, etc.) — only
+add what's missing. Don't pin exact versions unless a minimum is required; `Client.Add` without
+a version resolves the latest compatible release.
+
+The tables below are a starting point, not the whole registry. **Search the registry** to
+discover packages beyond this list, confirm an id exists, or check available versions before
+installing — see [Discovering and verifying packages](#discovering-and-verifying-packages).
+
+## Discovering and verifying packages
+
+Two ways to search, depending on whether the Editor is involved:
+
+**In-Editor — the PackageManager Client API (preferred).** `Client.SearchAll()` returns every
+package available in the project's configured registries (the Unity registry plus any scoped
+registries), each with all its versions and metadata — this is what the Package Manager
+window's search filters over. `Client.Search("<id>")` inspects a single package. Use the
+ready-to-run `PackageSearch` script in the main `SKILL.md` to discover candidates and verify
+ids/versions before building the install list.
+
+**Terminal — query the npm-compatible registry directly** (no Editor needed) to confirm a
+**known** id exists and list its versions:
+
+```bash
+# Full metadata for one package: versions{}, dist-tags.latest, description, dependencies.
+# -f makes curl fail (non-zero) on HTTP errors — e.g. a 404 for a bad id — instead of piping
+# an error page into python; -L follows redirects.
+curl -fsSL https://packages.unity.com/com.unity.cinemachine | python3 -m json.tool | head -40
+
+# Just the latest published version
+curl -fsSL https://packages.unity.com/com.unity.cinemachine \
+  | python3 -c "import sys,json;print(json.load(sys.stdin)['dist-tags']['latest'])"
+```
+
+Note: the registry supports fetching a **known** package id, but **not** free-text search over
+HTTP (the npm `-/v1/search` endpoint is not available — it 404s). For keyword discovery, use
+`Client.SearchAll()` in-Editor, the Package Manager window, or the
+[Unity package documentation](https://docs.unity3d.com/Manual/pack-keys.html).
+
+## Foundation (almost every project)
+
+| Need | Package | Notes |
+|---|---|---|
+| Modern input | `com.unity.inputsystem` | Preferred over the legacy Input Manager. |
+| Text / UI | `com.unity.ugui` | uGUI + TextMeshPro (bundled). UI Toolkit ships with the Editor. |
+| Camera framing | `com.unity.cinemachine` | Great for almost any 3D and many 2D games. |
+| Testing | `com.unity.test-framework` | Enables `unity test`; usually already present. |
+| Large/streamed assets | `com.unity.addressables` | Add when the game has many assets or needs content updates. |
+
+## Render pipeline (pick one; usually set by the template)
+
+| Choice | Package | Use when |
+|---|---|---|
+| **URP** (Universal) | `com.unity.render-pipelines.universal` | Default for most 2D/3D, mobile, and WebGL. Broadest platform reach. |
+| **HDRP** (High-Definition) | `com.unity.render-pipelines.high-definition` | High-fidelity PC/console only. Not for mobile/WebGL. |
+| **Built-in** | (none) | Simplest/legacy; fine for tiny prototypes. |
+
+## By dimension & look
+
+| Look | Packages |
+|---|---|
+| **2D** (any) | `com.unity.2d.feature` (sprites, tilemap, animation, pixel-perfect bundle) |
+| **2D pixel-perfect** | `com.unity.2d.pixel-perfect` (included in the 2D feature set) |
+| **3D navigation** | `com.unity.ai.navigation` (NavMesh for AI/pathfinding) |
+| **Cutscenes / sequencing** | `com.unity.timeline` |
+| **No-code logic** | `com.unity.visualscripting` |
+
+## By genre (starting points, combine with the above)
+
+| Genre | Typical additions |
+|---|---|
+| Platformer / action | URP, Input System, Cinemachine, 2D feature (if 2D), AI Navigation (if 3D) |
+| Puzzle / match / card | URP or 2D feature, Input System, uGUI/TextMeshPro, Timeline (juice) |
+| Top-down / twin-stick | URP, Input System, Cinemachine, AI Navigation |
+| RPG / adventure | URP, Input System, Cinemachine, AI Navigation, Addressables, Timeline |
+| Racing / physics | URP, Input System, Cinemachine; Physics is built in |
+| Idle / hyper-casual | 2D feature or URP, Input System, uGUI/TextMeshPro (keep it lean) |
+| Multiplayer (any) | `com.unity.netcode.gameobjects` + Multiplayer Services → see **build-live-game** |
+
+## By target platform
+
+Platform support is mostly Editor **modules** (installed with `unity install --module …`, see
+the **`unity-cli`** skill), not packages. Package-wise:
+
+| Platform | Consider |
+|---|---|
+| Mobile (iOS/Android) | Keep dependencies lean; URP over HDRP; Addressables for download size; monetization below |
+| WebGL | URP (not HDRP); small footprint; avoid heavy packages |
+| Desktop / Console | URP or HDRP depending on fidelity target |
+
+## By monetization — install now, integrate via the dedicated skill
+
+| Goal | Package | Integration skill |
+|---|---|---|
+| In-app purchases | `com.unity.purchasing` | **implement-in-app-purchases** |
+| Ads / mediation | `com.unity.services.levelplay` | **levelplay-unity-integration** |
+| Accounts, cloud save, economy, remote config, leaderboards, analytics | see the UGS package table | **build-live-game** |
+
+Install the package(s) here so the manifest is complete, but do the actual wiring by invoking
+the matching skill. For the full UGS package/version matrix (`com.unity.services.core`,
+`authentication`, `cloudsave`, `cloudcode`, `economy`, `remote-config`, `analytics`, etc.),
+read the **build-live-game** skill.


### PR DESCRIPTION
Adds `new-unity-project` and `unity-package-management`, copied unchanged from the public `Unity-Technologies/skills` repo where both already live and have been reviewed.

## Why they were missing

The plugin's skill list grew out of the `muse-skills` migration. These two were already on the public repo, so they never entered that migration pipeline, and nobody noticed the plugin had no copy. Checked the full scope: these are the only two skills present on the public repo's `main` and absent here.

They are also a pair. `new-unity-project` delegates package work to `unity-package-management`, so adding one without the other leaves a dangling reference.

## Why it matters more than a gap-fill

`new-unity-project` is the only skill that works for someone with no Unity project. Every other skill assumes a project exists, and ten of them need a live Editor. Without it, a user who installs the plugin and asks for help making a game has nowhere to start.

## Tested

Run in an empty directory with no Unity project, prompt: "I want to make a small 2D platformer game. Can you get me set up?"

The skill triggered on its own, checked the CLI version, auth state, license and installed Editors, reported that an Editor was already present so there would be no install wait, then asked the concept questions its design calls for and offered a defaults path. Answering `defaults` produced:

- A real project at `FunnelTest` on `6000.5.8f1`, from the `com.unity.template.universal-2d` template
- Packages handled by checking the template contents first and adding only what was missing (Cinemachine 3.1.7 plus Splines). It also verified `PixelPerfectCamera` already ships inside URP rather than installing a redundant package
- A git repo on `main` with a Unity `.gitignore` and an initial commit of 52 files, with `Library/`, `Temp/`, `Logs/` and `UserSettings/` excluded
- An explicit report that the machine's auth session was stale and that builds would likely fail until `unity auth login` runs, with a note that it could not fix that itself

Two limits worth recording. The machine already had an Editor installed, so the install-from-scratch path was not exercised. And package delegation happened by reading the sibling skill's files rather than through a separate skill invocation, so a transcript that only counts `Skill` tool calls will not show it.
