### PR TITLE
fix(optimize-web): persist settings and verify them from disk

### DIFF
--- a/skills/optimize-web/SKILL.md
+++ b/skills/optimize-web/SKILL.md
@@ -75,6 +75,14 @@ return string.Join("\n", w);
 installed. Read it in a separate call from the rest, and treat a resolution failure as "the Web
 module isn't installed" rather than as a bad snippet.
 
+**`codeOptimization` is the one setting here that does not live in the project file.** It persists to
+`Library/EditorUserBuildSettings.asset`, and `Library/` is gitignored by every standard Unity
+`.gitignore`, so this value is per-machine and does not travel: teammates and CI do not inherit it.
+Two consequences. Read it back through the API and do not look for it in
+`ProjectSettings/ProjectSettings.asset` — it is absent there even on a successful apply, so its
+absence is not a failure. And if the release build runs in CI, apply it there as a build step rather
+than assuming the repository carries it.
+
 ### Applying the settings
 
 Most of the writes in this skill are a single batch, and
@@ -111,6 +119,12 @@ So after any write:
 The same trap exists on the file-editing route in reverse: a hand-edited
 `ProjectSettings.asset` reads back fine while the running Editor and the build still use the old
 value. Verifying after a save and a reimport is what catches both.
+
+**Do not try to reproduce this in batch mode.** A batch Editor invoked with `-quit` saves settings on
+exit, so an unsaved write persists anyway and the run looks correct. Both a saving and a non-saving
+version of the script pass under `-quit`. The bug only appears in a live Editor session, which is
+where it was found. Concluding from a green batch run that the save is unnecessary is the wrong
+conclusion from a test that cannot see the defect.
 
 ## 0. Pre-Flight
 

--- a/skills/optimize-web/SKILL.md
+++ b/skills/optimize-web/SKILL.md
@@ -90,6 +90,28 @@ UnityEditor.EditorApplication.ExecuteMenuItem("Tools/Apply Web Release Settings"
 Keep its `using` directives; they are correct in a file. For one-off changes — a single quality
 level, a frame-rate flip — an inline `eval` statement is fine.
 
+### Verify from disk, not from the objects you just wrote
+
+**Applying a setting and reading it back in the same session proves nothing.** Player Settings are
+in-memory objects until something saves them, so every read-back returns the value you just
+assigned whether or not it ever reached
+`ProjectSettings/ProjectSettings.asset`. A run that skips the save reports success, and when the
+Editor session ends the whole change is gone. This was observed, not theorised: a run applied
+everything, read back Brotli / High / None, said it was done, and the file on disk never changed.
+
+So after any write:
+
+1. **Save.** `UnityEditor.AssetDatabase.SaveAssets()`. `WebOptimizer.cs` now does this itself; an
+   inline `eval` write has to do it explicitly.
+2. **Read the values back and report them.** Not "applied successfully" but the actual values, so the
+   user can see what is stored. `WebOptimizer.cs` logs all nine.
+3. **For anything per-build-target, name the target you read.** Several of these settings exist once
+   per target, so a value can be correct for one target and unset for the one being built.
+
+The same trap exists on the file-editing route in reverse: a hand-edited
+`ProjectSettings.asset` reads back fine while the running Editor and the build still use the old
+value. Verifying after a save and a reimport is what catches both.
+
 ## 0. Pre-Flight
 
 1. **Confirm Web build target:** Read, with the Pre-Flight snippet above, `EditorUserBuildSettings.activeBuildTarget` — must be `WebGL`; if not, warn the user.

--- a/skills/optimize-web/resources/WebOptimizer.cs
+++ b/skills/optimize-web/resources/WebOptimizer.cs
@@ -1,5 +1,6 @@
 using UnityEditor;
 using UnityEditor.Build;
+using UnityEngine;
 
 public class WebOptimizer
 {
@@ -17,5 +18,25 @@ public class WebOptimizer
         PlayerSettings.WebGL.wasm2023 = true;
         UnityEditor.WebGL.UserBuildSettings.codeOptimization =
             UnityEditor.WebGL.WasmCodeOptimization.DiskSizeLTO;
+
+        // Persist. Without this the settings are applied to the in-memory objects only: every
+        // read-back below returns the new value, the run reports success, and nothing reaches
+        // ProjectSettings/ProjectSettings.asset. When the Editor session ends the whole change
+        // is gone. Observed in testing, so it is not theoretical.
+        AssetDatabase.SaveAssets();
+
+        // Read back from the settings after saving and report what was actually stored. Assigning
+        // a property and assuming it took is the failure this method exists to demonstrate.
+        Debug.Log(
+            "Web release settings applied and saved:\n"
+            + $"  il2cppCodeGeneration = {PlayerSettings.GetIl2CppCodeGeneration(target)}\n"
+            + $"  managedStrippingLevel = {PlayerSettings.GetManagedStrippingLevel(target)}\n"
+            + $"  stripUnusedMeshComponents = {PlayerSettings.stripUnusedMeshComponents}\n"
+            + $"  dataCaching = {PlayerSettings.WebGL.dataCaching}\n"
+            + $"  compressionFormat = {PlayerSettings.WebGL.compressionFormat}\n"
+            + $"  exceptionSupport = {PlayerSettings.WebGL.exceptionSupport}\n"
+            + $"  debugSymbolMode = {PlayerSettings.WebGL.debugSymbolMode}\n"
+            + $"  wasm2023 = {PlayerSettings.WebGL.wasm2023}\n"
+            + $"  codeOptimization = {UnityEditor.WebGL.UserBuildSettings.codeOptimization}");
     }
 }

--- a/skills/optimize-web/resources/WebOptimizer.cs
+++ b/skills/optimize-web/resources/WebOptimizer.cs
@@ -27,6 +27,10 @@ public class WebOptimizer
 
         // Read back from the settings after saving and report what was actually stored. Assigning
         // a property and assuming it took is the failure this method exists to demonstrate.
+        // Eight of the nine land in ProjectSettings/ProjectSettings.asset. codeOptimization is the
+        // exception: it persists to Library/EditorUserBuildSettings.asset, which is gitignored, so
+        // it is per-machine and absent from the project file even on success. Verify that one
+        // through this log, not by grepping ProjectSettings.asset, and re-apply it in CI.
         Debug.Log(
             "Web release settings applied and saved:\n"
             + $"  il2cppCodeGeneration = {PlayerSettings.GetIl2CppCodeGeneration(target)}\n"


### PR DESCRIPTION
`optimize-web`'s `WebOptimizer.cs` applied nine settings and never saved them. In testing, a run applied everything in a live Editor, read back Brotli / High / None, reported success, and the file on disk never changed. When the session ended the whole change was gone. The runs that appeared to pass had each added their own save call, so the shipped template was the one thing missing.

This is the same shape as a bug fixed in `localization` recently, where a font asset's material read back fine and never reached disk. Reading back the object you just wrote proves the assignment happened, not that anything persisted.

## The fix

`WebOptimizer.cs` now calls `AssetDatabase.SaveAssets()` after the writes, then reads all nine settings back and logs the stored values rather than printing "success". The comment explains what happens without the save, so the line does not get dropped again as noise.

`SKILL.md` gains a short section next to the apply step: save, read the values back and report them, and name the build target for anything that is per-target. It also notes the mirror-image failure on the file-editing route, where a hand-edited `ProjectSettings.asset` reads back fine while the Editor and the build still use the old value. Verifying after a save and a reimport is what catches both.

## Scope: only this one skill needed it

I turned the rule into a checker and ran it over every C# file in this branch, looking for anything that writes settings or assets without a save, reimport or dirty call. It flagged 16 files. On inspection 15 are false positives:

- `ScriptablePacker` implementations writing to output structures rather than assets
- scene-component edits, which persist through the scene save rather than `SaveAssets`
- temporary `RenderTexture` work explicitly marked `HideAndDontSave`

The two neighbours worth checking by hand were already correct. `optimize-audio` persists through `SaveAndReimport()` on the importer. `urp-postprocessing` calls `SetDirty` then `SaveAssets`, and already documents the `sharedProfile` versus `profile` distinction, which is the same trap in a different place.

So this is a single-point defect rather than a systemic pattern, which is worth knowing: a hand pass found it and a grep over the tree would not have.

## Verified

Every API this change relies on was executed against a live Editor on Unity 6000.5.8f1, with positive and negative controls first, because an earlier attempt at this verification silently passed against a closed Editor and had to be thrown away.

- `PlayerSettings.GetIl2CppCodeGeneration(NamedBuildTarget.WebGL)` and `GetManagedStrippingLevel(...)` both resolve and return real values. These were previously only inferred from the setters already in the file.
- The six `PlayerSettings.WebGL` getters plus `stripUnusedMeshComponents` all resolve and return the project's actual values.
- `AssetDatabase.SaveAssets()` and `UnityEngine.Debug.Log` compile with the `using` set the file now has.

`UnityEditor.WebGL.UserBuildSettings.codeOptimization` was the one line I could not verify, because it needs the WebGL build-support module and the test Editor does not have it. Review has since closed that gap: it resolves and applies on a module-equipped 6000.5.8f1, confirmed against a project with all three defects planted, and the new log prints `DiskSizeLTO`.

## Added after review

Two findings from review, both documented rather than coded around.

**`codeOptimization` does not live in the project file.** It persists to `Library/EditorUserBuildSettings.asset`, which every standard Unity `.gitignore` excludes, so the value is per-machine and teammates and CI do not inherit it. Verified independently on a second project: the file exists, `Library/` is ignored at line 4 of `.gitignore`, and `codeOptimization` appears zero times in `ProjectSettings.asset`. Two things follow, and the skill now says both: its absence from `ProjectSettings.asset` is not a failure, so read it back through the API instead; and a CI release build has to apply it as a build step.

**Batch mode cannot reproduce this bug.** A batch Editor invoked with `-quit` saves settings on exit, so an unsaved write persists anyway and both the fixed and the original script pass. The defect only appears in a live Editor session, which is where it was found. That is worth a paragraph in the skill rather than only a note here, because a green batch run is easy to read as evidence the save is unnecessary.
