### PR TITLE
fix: persist scene and asset edits in the reference snippets

### DIFF
--- a/skills/localization/references/api-notes.md
+++ b/skills/localization/references/api-notes.md
@@ -18,6 +18,10 @@ string guid = AssetDatabase.AssetPathToGUID(AssetDatabase.GetAssetPath(myAsset))
 var entry = table.GetEntry(sharedEntryId) ?? table.AddEntry(sharedEntryId, guid);
 entry.Guid = guid;
 EditorUtility.SetDirty(table);
+// SetDirty only marks the table. Without a save the entry reads back correctly for the rest of
+// the session and is gone when the Editor closes. See the save sequence in SKILL.md: dirty the
+// collection and its SharedData too, then save once at the end.
+AssetDatabase.SaveAssets();
 ```
 
 ## Common Namespace Conflicts (CS0118)

--- a/skills/urp-postprocessing/references/code-templates.md
+++ b/skills/urp-postprocessing/references/code-templates.md
@@ -67,9 +67,13 @@ return $"Post-processing enabled on '{cam.name}'. Scene '{scene.name}' is modifi
      + "Save it, or the change is lost when the Editor session ends.";
 ```
 
-To save it for the user instead of asking, call
-`UnityEditor.SceneManagement.EditorSceneManager.SaveScene(scene)`. Prefer reporting first: a save
-also commits whatever else the user had in progress in that scene.
+The right choice depends on whether anyone is watching:
+
+- **Interactive run** (the user is at the Editor): report and let them save. A save from here also
+  commits whatever else they had in progress in that scene, which is not yours to decide.
+- **Non-interactive run** (batch, CI, or a session that is about to end): call
+  `UnityEditor.SceneManagement.EditorSceneManager.SaveScene(scene)` and say that you saved it.
+  Nobody is there to act on a "scene is unsaved" report, so leaving it unsaved just loses the work.
 
 ### Modifying an Existing Volume Profile
 

--- a/skills/urp-postprocessing/references/code-templates.md
+++ b/skills/urp-postprocessing/references/code-templates.md
@@ -56,21 +56,43 @@ if (!cam.TryGetComponent<UnityEngine.Rendering.Universal.UniversalAdditionalCame
 UnityEditor.Undo.RecordObject(data, "Enable Post-Processing");
 data.renderPostProcessing = true;
 UnityEditor.EditorUtility.SetDirty(data);
-return $"Post-processing enabled on '{cam.name}'.";
+
+// This edits a component, which lives in the scene rather than in an asset, so
+// AssetDatabase.SaveAssets() does not persist it. SetDirty only marks; nothing is written until
+// the scene is saved. Mark the scene and say it is unsaved, rather than reporting the change as
+// done: if the session ends without a scene save, the edit is gone.
+var scene = data.gameObject.scene;
+UnityEditor.SceneManagement.EditorSceneManager.MarkSceneDirty(scene);
+return $"Post-processing enabled on '{cam.name}'. Scene '{scene.name}' is modified but NOT saved. "
+     + "Save it, or the change is lost when the Editor session ends.";
 ```
+
+To save it for the user instead of asking, call
+`UnityEditor.SceneManagement.EditorSceneManager.SaveScene(scene)`. Prefer reporting first: a save
+also commits whatever else the user had in progress in that scene.
 
 ### Modifying an Existing Volume Profile
 
+**Use `sharedProfile`, not `profile`.** `profile` auto-clones the asset into a runtime instance, so
+`SetDirty` on it marks a clone that is not an asset at all and the edit can never reach disk. Merely
+reading `volume.profile` is enough to trigger the clone, so the null check has to use `sharedProfile`
+too. `sharedProfile` returns the asset itself, which is what an Editor-time edit needs.
+
 ```csharp
 var volumeObj = UnityEngine.GameObject.Find("Global Volume");
-if (volumeObj != null && volumeObj.TryGetComponent<UnityEngine.Rendering.Volume>(out var volume) && volume.profile != null)
+if (volumeObj != null && volumeObj.TryGetComponent<UnityEngine.Rendering.Volume>(out var volume)
+    && volume.sharedProfile != null)
 {
-    if (volume.profile.TryGet<UnityEngine.Rendering.Universal.Bloom>(out var bloom))
+    var profile = volume.sharedProfile;
+    if (profile.TryGet<UnityEngine.Rendering.Universal.Bloom>(out var bloom))
     {
         bloom.intensity.overrideState = true;
         bloom.intensity.value = 2f;
     }
-    UnityEditor.EditorUtility.SetDirty(volume.profile);
+    UnityEditor.EditorUtility.SetDirty(profile);
+    // SetDirty only marks the asset. Without this the edit is in memory only: it reads back
+    // correctly for the rest of the session and is lost when the session ends.
+    UnityEditor.AssetDatabase.SaveAssets();
 }
 ```
 
@@ -94,6 +116,11 @@ UnityEditor.Undo.RegisterCompleteObjectUndo(target, "Set up post-processing");  
 // UnityEditor.Undo.RegisterCreatedObjectUndo(newObject, "Set up post-processing");
 UnityEditor.EditorUtility.SetDirty(target);
 
+// SetDirty marks; it does not write. Persist according to what `target` is, or the change is
+// lost at session end even though every read-back looks correct:
+//   an asset (Volume Profile, URP Asset)  -> UnityEditor.AssetDatabase.SaveAssets();
+//   a component in a scene                -> MarkSceneDirty(target.gameObject.scene) and tell
+//                                            the user the scene needs saving
 UnityEditor.Undo.FlushUndoRecordObjects();         // force the snapshot out now
 UnityEditor.Undo.CollapseUndoOperations(group);    // one entry, not several
 


### PR DESCRIPTION
Follow-up to #26. Review of that PR flagged two snippets in `urp-postprocessing/references/code-templates.md` with the same latent shape, which exposed a hole in how the scope was checked: #26 swept `.cs` files, review swept `.cs` plus `SKILL.md`, and neither read `references/*.md`. That is 87 of the 116 markdown files under `skills/`.

Extending the sweep to every C# block in all 116 files gives 11 candidates, 4 real, in 2 skills.

## `urp-postprocessing/references/code-templates.md`

**"Modifying an Existing Volume Profile" was using the wrong property, so a save alone would not have fixed it.** It read and dirtied `volume.profile`, but this skill's own SKILL.md says `profile` auto-clones the asset into a runtime instance while `sharedProfile` returns the asset. `SetDirty` on the clone marks something that is not an asset, so the edit can never reach disk. Merely reading `volume.profile` triggers the clone, so the null check had to change too. Now uses `sharedProfile` throughout, plus `SaveAssets()`.

**"Enabling Post-Processing on Camera" edits a component, so `SaveAssets()` is the wrong tool.** The value lives in the scene, not in an asset. It now marks the scene and returns a string saying the scene is modified and unsaved, instead of reporting the change as done. `SaveScene` is mentioned as the alternative, with the reason to prefer reporting: a save also commits whatever else the user had in progress in that scene.

**The undo template ended at `SetDirty(target)`** with a `// ... make the modification` placeholder, which makes it the archetype the other two followed. It now carries the persistence step for both cases, asset and scene component.

## `localization/references/api-notes.md`

The Asset Table entry snippet dirties the table and never saves. The doctrine is already correct in that skill's SKILL.md, which says to dirty the collection and its `SharedData` and save once at the end. A reference file gets read on its own, so the snippet now carries the save and points at the full sequence.

## Two candidates that look like this bug and are not

Worth recording, because both were initially miscounted as real and the reason is the same in both directions.

`audio-setup-mixers/references/api.md` routes Audio Sources with `SetDirty(source)` and no save. The prose three lines under the snippet already says the routing only persists once the scene is saved, and names `SaveOpenScenes()`. Reading the code block in isolation is what produced the false positive.

`localization/resources/L10nBatchProcessor.cs` dirties a `LocalizeStringEvent` component, and does `OpenScene` / `MarkSceneDirty` / `SaveScene` around the loop. Correct as written.

The other 7 remaining sweep hits are the false-positive class review already identified: property signature listings in `manage-sprite-atlas/references/api.md`, a read-only report builder, a commented-out revert snippet, and a `PlayerSettings` write scoped to a build callback.

## Verified

Compile-checked against a live Editor on Unity 6000.5.8f1, positive and negative controls first. URP is present in the test project, so the URP types resolve rather than being skipped.

- `volume.sharedProfile` plus `TryGet<Bloom>` plus `SetDirty` plus `SaveAssets` compiles as written.
- `EditorSceneManager.MarkSceneDirty(data.gameObject.scene)` and `SaveScene(scene)` both compile.
- Both rewritten snippets were compiled in their exact final form, not paraphrased.

All checks were compile-only, so nothing in the test project was modified.

## Not in this PR

`localization/references/api-notes.md` is byte-identical on `main`, and both it and the urp file are identical in `Unity-Technologies/skills`, so both copies still need the same fix. Those ports are separate PRs.

