### PR TITLE
docs: clarify which install commands are slash commands, and make the description agent-neutral

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "unity",
   "version": "0.1.0-beta",
-  "description": "Unity's official plugin for Claude Code, with curated skills for game development, monetization, and performance optimization.",
+  "description": "Unity's official plugin for coding agents, with curated skills for game development, monetization, and performance optimization.",
   "author": {
     "name": "Unity Technologies",
     "url": "https://unity.com"

--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@ Available for **Claude Code**, **Codex**, and **Grok**.
 
 ## Install
 
-**Claude Code**
+**Claude Code** — these two are slash commands, so type them inside a Claude Code
+session rather than in a terminal:
 
 ```
 /plugin marketplace add Unity-Technologies/unity-agent-plugin
@@ -15,6 +16,14 @@ Available for **Claude Code**, **Codex**, and **Grok**.
 
 ```
 /plugin install unity@unity-agent-plugin
+```
+
+From a terminal instead, use the `claude` CLI. Installs done this way load the next
+time you start Claude Code, or when you run `/reload-plugins` in an open session:
+
+```bash
+claude plugin marketplace add Unity-Technologies/unity-agent-plugin
+claude plugin install unity@unity-agent-plugin
 ```
 
 **Codex**


### PR DESCRIPTION
Two small things, both about the plugin being used from three agents rather than one.

**The README did not say which install commands are slash commands.** The Claude Code block is `/plugin marketplace add` and `/plugin install`, which only work typed inside a session; in a terminal they do nothing. The Codex and Grok blocks below them are real shell commands, so the page put three code blocks in a row where the first two behave differently from the rest with nothing marking the difference. The only signal was a missing `bash` language tag, which is not something a reader notices.

Now labelled, with the terminal equivalent added for anyone who wants it:

```bash
claude plugin marketplace add Unity-Technologies/unity-agent-plugin
claude plugin install unity@unity-agent-plugin
```

Both verified against the installed CLI. The note that a shell install loads on next launch, or on `/reload-plugins` in an open session, is there because otherwise it looks like it silently failed.

**`plugin.json` said "Unity's official plugin for Claude Code".** Codex and Grok both read that same manifest and surface the description in their own listings, so `grok plugin details unity` was telling a Grok user this is a Claude Code plugin. Changed to "for coding agents".

`marketplace.json` already used neutral wording in both of its description fields, so it needed no change.

## Checked

- `claude plugin marketplace add` and `claude plugin install` both exist with the arguments shown.
- `claude plugin validate` passes, and the skills structural gate passes.
- `grok plugin validate` reads the manifest and now reports the neutral description.
- Codex reads `.codex-plugin/plugin.json`, whose description says "for Codex" and stays that way.
  The split is deliberate rather than inconsistent: that manifest is read only by Codex, while
  `.claude-plugin/plugin.json` is read by both Claude Code and Grok, which is why that one has to be
  agent-neutral. Confirmed by running `grok plugin validate` against the repo: Grok resolves the
  Claude manifest, not a Grok-specific one, and none is needed.
