### PR TITLE
feat: label CLI invocations with caller and skill (blocked on the next CLI release)

### DIFF
--- a/skills/audio-setup-mixers/SKILL.md
+++ b/skills/audio-setup-mixers/SKILL.md
@@ -40,7 +40,7 @@ Once `eval` is available, that is how each C# step below runs.
 
 Run C# through the connected Editor with the `eval` command. Discover its parameter shape
 from `unity command --format json` rather than assuming one — the inline form is
-`unity command eval --code '<snippet>'`, and some Pipeline versions also register
+`unity command eval --caller plugin --skill audio-setup-mixers --code '<snippet>'`, and some Pipeline versions also register
 `eval_file` for running a snippet from a file. **Check the catalog before reaching for
 `eval_file`; it is frequently absent.** `unity command` defaults to a 30 second timeout.
 

--- a/skills/audio-setup-mixers/references/api.md
+++ b/skills/audio-setup-mixers/references/api.md
@@ -27,7 +27,7 @@ to add any missing groups (two clicks in a window they already have open), and t
 routing itself. The tedious part — walking dozens of Audio Sources and classifying them — is the
 part that was worth automating anyway.
 
-All snippets below are written for `unity command eval --code '<snippet>'`: fully qualified, no
+All snippets below are written for `unity command eval --caller plugin --skill audio-setup-mixers --code '<snippet>'`: fully qualified, no
 `using` directives, returning their result rather than logging it.
 
 ## Inventory the project's mixers and their groups

--- a/skills/generate-editor-search-query/references/open-search-window.md
+++ b/skills/generate-editor-search-query/references/open-search-window.md
@@ -8,7 +8,7 @@ This is a read-only Editor UI action. It must not create, modify, delete, import
 
 Replace `QUERY_HERE` with the generated Unity Search query. If the query contains double quotes, double them inside the verbatim C# string.
 
-Run it through the Editor with `unity command eval --code '<snippet>'`. Fully qualified, with no
+Run it through the Editor with `unity command eval --caller plugin --skill generate-editor-search-query --code '<snippet>'`. Fully qualified, with no
 `using` directives, because `eval` compiles a statement block rather than a file.
 
 ```csharp

--- a/skills/migrate-birp-to-urp/SKILL.md
+++ b/skills/migrate-birp-to-urp/SKILL.md
@@ -111,7 +111,7 @@ Two things it can't know for you:
   materials, and rebaking lighting all need a live Editor. An unreachable Editor is a stop, not a
   cue to hand-edit `ProjectSettings/GraphicsSettings.asset`.
 
-Run C# with `unity command eval --code '<snippet>'`. `unity command` defaults to a 30 second
+Run C# with `unity command eval --caller plugin --skill migrate-birp-to-urp --code '<snippet>'`. `unity command` defaults to a 30 second
 timeout, which matters here: installing URP triggers a package refresh and domain reload that will
 outlast it. Treat that as a phase boundary rather than raising the timeout.
 

--- a/skills/optimize-audio/SKILL.md
+++ b/skills/optimize-audio/SKILL.md
@@ -26,7 +26,7 @@ Two things it can't know for you:
   through `SaveAndReimport()` in a live Editor, so an unreachable Editor is a stop, not a cue to
   edit metadata directly.
 
-Run C# with `unity command eval --code '<snippet>'`. Discover the parameter shape from
+Run C# with `unity command eval --caller plugin --skill optimize-audio --code '<snippet>'`. Discover the parameter shape from
 `unity command --format json` rather than assuming one. `unity command` defaults to a 30 second
 timeout.
 

--- a/skills/optimize-audio/resources/audio-import-api.md
+++ b/skills/optimize-audio/resources/audio-import-api.md
@@ -1,6 +1,6 @@
 # Audio Import API Recipes
 
-C# code recipes for `unity command eval --code '<snippet>'`. All examples target the Unity 6
+C# code recipes for `unity command eval --caller plugin --skill optimize-audio --code '<snippet>'`. All examples target the Unity 6
 AudioImporter API.
 
 `eval` compiles a statement block, so there are no `using` directives and every type is written

--- a/skills/optimize-web/SKILL.md
+++ b/skills/optimize-web/SKILL.md
@@ -24,7 +24,7 @@ Two things it can't know for you:
   are per-build-target, and a hand-edited value silently disagrees with what the build actually
   uses. An unreachable Editor is a stop for the write steps.
 
-Run C# with `unity command eval --code '<snippet>'`. `unity command` defaults to a 30 second
+Run C# with `unity command eval --caller plugin --skill optimize-web --code '<snippet>'`. `unity command` defaults to a 30 second
 timeout.
 
 ### Passing C# to `eval`

--- a/skills/sprite-editor/SKILL.md
+++ b/skills/sprite-editor/SKILL.md
@@ -24,7 +24,7 @@ Two things it can't know for you:
 
 Run C# through the connected Editor with the `eval` command. Discover its parameter shape
 from `unity command --format json` rather than assuming one — the inline form is
-`unity command eval --code '<snippet>'`, and some Pipeline versions also register
+`unity command eval --caller plugin --skill sprite-editor --code '<snippet>'`, and some Pipeline versions also register
 `eval_file` for running a snippet from a file. **Check the catalog before reaching for
 `eval_file`; it is frequently absent.** `unity command` defaults to a 30 second timeout.
 

--- a/skills/unity-cli/SKILL.md
+++ b/skills/unity-cli/SKILL.md
@@ -16,8 +16,12 @@ unity status                    # confirm a connected Editor (look for state "re
 unity command                   # list the commands the Editor exposes
 unity command editor_play       # run one — e.g. enter Play mode
 # Run arbitrary C# — e.g. add a GameObject named "Joe" — when the Editor exposes eval:
-unity command eval 'new UnityEngine.GameObject("Joe");'
+unity command eval --caller plugin --skill unity-cli 'new UnityEngine.GameObject("Joe");'
 ```
+
+**Pass `--caller plugin --skill <name>` on every `unity command` invocation.** `--skill` is the
+skill whose instructions produced the call, so a task skill that sends you here passes its own name
+rather than `unity-cli`. The flags are inert to the command itself; they only label the invocation.
 
 ### More than one Editor open? Pass `--project-path`
 

--- a/skills/urp-postprocessing/SKILL.md
+++ b/skills/urp-postprocessing/SKILL.md
@@ -23,7 +23,7 @@ missing, say so and stop.
 
 Run C# through the connected Editor with the `eval` command. Discover its parameter shape
 from `unity command --format json` rather than assuming one — the inline form is
-`unity command eval --code '<snippet>'`, and some Pipeline versions also register
+`unity command eval --caller plugin --skill urp-postprocessing --code '<snippet>'`, and some Pipeline versions also register
 `eval_file` for running a snippet from a file. **Check the catalog before reaching for
 `eval_file`; it is frequently absent.** `unity command` defaults to a 30 second timeout.
 


### PR DESCRIPTION
## What

Every `unity command` example in a skill that drives the Editor now passes `--caller plugin --skill <name>`, and `unity-cli` states the rule so it applies to the invocations no example covers:

> **Pass `--caller plugin --skill <name>` on every `unity command` invocation.** `--skill` is the skill whose instructions produced the call, so a task skill that sends you here passes its own name rather than `unity-cli`.

## Why

A CLI call made by this plugin is otherwise indistinguishable from one a user typed, so plugin usage cannot be told apart from CLI usage generally, and per-skill usage cannot be seen at all. The two flags carry that on the command line, which is the only place it can travel: by the time the CLI starts, nothing in the process, the args, or the environment records that a skill produced the call.

## Coverage

All eight skills that invoke `unity command`:

`unity-cli`, `audio-setup-mixers`, `optimize-audio`, `optimize-web`, `sprite-editor`, `urp-postprocessing`, `migrate-birp-to-urp`, `generate-editor-search-query`

`new-unity-project` and `unity-package-management` drive the CLI too, but through `unity install` and `unity projects`, which do not take these flags — so their usage stays invisible to this. Worth knowing before reading any per-skill numbers.

## Blocked on

The next CLI release, not on a code change. Both halves are merged and sitting in `[Unreleased]`:

- [CLI-951](https://jira.unity3d.com/browse/CLI-951) added `--caller` and `--skill` to `unity command`.
- [CLI-1152](https://jira.unity3d.com/browse/CLI-1152) stopped `--caller plugin` folding to `other`, which it did on the first implementation.

Merging before that release ships would break these eight skills: the released CLI (`1.0.0-beta.8`) rejects `--caller` as an unknown option.

## How To Test/Validate

Against a CLI built from `dev`, with a connected Editor:

```
unity command eval --caller plugin --skill unity-cli 'new UnityEngine.GameObject("Joe");'
```

The command behaves exactly as it does without the flags. To see the labels reach analytics, point the CLI at a local collector with `UNITY_CLI_INTERNAL_ANALYTICS_URL` and check `caller` and `skill` on the `command executed` event. Note that CLI analytics resolves to the `anonymous` consent row, so that row has to be opted in for anything to be sent.
