### PR TITLE
chore: add the frontmatter name field to the 18 skills missing it

### DIFF
--- a/skills/2d-pixel-perfect/SKILL.md
+++ b/skills/2d-pixel-perfect/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: 2d-pixel-perfect
 description: Sets up, diagnoses, and fixes pixel perfect 2D rendering in Unity projects. Use when working on any retro-style or pixel art 2D game.
 ---
 

--- a/skills/build-live-game/SKILL.md
+++ b/skills/build-live-game/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: build-live-game
 description: Build and operate a live game using Unity Services. Use when the user needs to implement, connect, or debug backend-driven features — battle passes, achievements, player progression, cloud saves, leaderboards, matchmaking, virtual economies, server-authoritative logic, anti-cheat, player accounts and authentication, remote configuration, feature flags, A/B testing, analytics, or cloud resource deployment. Triggers on live-ops, live service, backend, server authority, cloud code, cloud save, remote config, player data, retention, monetization loop, season pass, ranking, multiplayer sessions, lobbies, or any Unity Services integration.
 ---
 

--- a/skills/implement-in-app-purchases/SKILL.md
+++ b/skills/implement-in-app-purchases/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: implement-in-app-purchases
 description: Implement, configure, and debug Unity In-App Purchases (IAP) — store connection, product catalog, consumable/non-consumable/subscription purchases, two-step pending-confirm flow, receipt validation, entitlement checking, restore transactions, Apple extensions (promotional purchases, Ask-to-Buy, code redemption), and Google Play extensions (subscription upgrade/downgrade), D2C Capabilities(direct to customer), 3rd party payment provider (Stripe/Coda) via Unity IAP/Unity Cloud. Use when the user needs to add, modify, debug, or migrate from native Android/iOS billing, 3rd party packages(RevenueCat/Adapty/Essential Kit/Unipay supported) to IAP. Triggers on microtransactions (MTX), monetization, real-money purchases, store purchases, buying items, support D2C, purchase via Stripe/Coda, migrate from native billing(Google's BillingClient or Apple's StoreKit/SKPaymentQueue/SKProduct)/RevenueCat/Adapty/EssentialKit/Unipay.
 ---
 

--- a/skills/levelplay-unity-integration/SKILL.md
+++ b/skills/levelplay-unity-integration/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: levelplay-unity-integration
 description: Integrates the LevelPlay Mediation SDK via the Ads Mediation UPM package. Use when a developer asks about adding ads to a Unity game, implementing rewarded, interstitial, or banner ads, setting up ad mediation, configuring ad networks, installing or updating the Ads Mediation package, troubleshooting LevelPlay namespace errors, resolving Android gradle or iOS CocoaPods dependency issues for ads, configuring ATT or privacy settings for ad compliance, tracking impression-level revenue (ILRD), initializing the LevelPlay SDK, or setting up ad unit IDs. Also use when a developer wants to monetize their Unity game with ads, asks how to get started with LevelPlay, ads, or mediation, or needs help with any part of the LevelPlay integration workflow including platform-specific setup for iOS or Android. Also use when upgrading the LevelPlay or IronSource SDK version, migrating from deprecated IronSource.Agent APIs, or migrating a game from Unity Ads to LevelPlay.
 ---
 

--- a/skills/localization/SKILL.md
+++ b/skills/localization/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: localization
 description: "Sets up and configures Unity Localization, including locales, String/Asset Tables, CJK font support, and Addressables workflows. Use when the user wants to add languages to a project, translate UI text, support Asian (CJK) languages with TMP fonts, or mentions i18n, l10n, multilingual support, or making a game support multiple languages."
 ---
 

--- a/skills/manage-sprite-atlas/SKILL.md
+++ b/skills/manage-sprite-atlas/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: manage-sprite-atlas
 description: Manage SpriteAtlas using prebuild pipeline with IPreprocessBuildWithReport (DEFAULT approach). Use it to configure master atlases, variant atlases, texture settings, packing settings, and platform-specific configurations. Use when the user asks about creating sprite atlases, optimizing sprites, configuring atlas settings, adding sprites to atlases, creating variant atlases, implementing automated atlas generation, or runtime sprite atlas access. Always use prebuild approach unless user explicitly requests manual authoring.
 ---
 

--- a/skills/optimize-text-mesh-pro/SKILL.md
+++ b/skills/optimize-text-mesh-pro/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: optimize-text-mesh-pro
 description: >
   Covers TextMeshPro font stacks, dynamic fallback atlases, padding and
   sampling ratios, SDF16, AutoSize discipline, worldspace vs UGUI, and Memory

--- a/skills/setup-multiplayer-services/SKILL.md
+++ b/skills/setup-multiplayer-services/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: setup-multiplayer-services
 description: >-
   Guides the development of online multiplayer experiences where players connect, group, and interact in real-time using Unity Multiplayer Services.
   Use when the user asks for topology choice, player grouping, hosting, matchmaking, discovery, network setup,

--- a/skills/shader-graph-create-custom-node/SKILL.md
+++ b/skills/shader-graph-create-custom-node/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: shader-graph-create-custom-node
 description: "Generates custom Shader Graph nodes from HLSL code. Use when the user wants to create a new Shader Graph node or make existing HLSL code work as a reflected function node."
 required_packages:
   com.unity.shadergraph: ">=17.5.0"

--- a/skills/sprite-segment-3x3grid/SKILL.md
+++ b/skills/sprite-segment-3x3grid/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: sprite-segment-3x3grid
 description: Analyze Sprite textures and output a 3x3 grid representation based on color matching. Segments a Sprite into a 3x3 grid, identifies the majority color of the center cell, and outputs a text pattern showing which cells match the center color. Use when analyzing sprite patterns, documenting sprite structure, or describing sprite color distribution.
 ---
 # Sprite Color Grid Analysis

--- a/skills/tilemap-palette-create/SKILL.md
+++ b/skills/tilemap-palette-create/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: tilemap-palette-create
 description: Creates a Tile Palette asset. Use when the user wants to organize tiles for 2D level design or create a new Tile Palette from scratch. The user can specify the Grid layout, eg. Rectangular, Hexagonal, Isometric.
 required_packages:
   com.unity.2d.tilemap: ">=1.0.0"

--- a/skills/tilemap-ruletile-createempty/SKILL.md
+++ b/skills/tilemap-ruletile-createempty/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: tilemap-ruletile-createempty
 description: Creates an empty RuleTile asset without Sprite or Spritesheet inputs. Use ONLY when the user wants a blank RuleTile, HexagonalRuleTile, or IsometricRuleTile for custom rule configuration AND has not provided or referenced any sprites. If the user mentions existing sprites, terrain art, edge tiles, or a tiles folder, use tilemap-ruletile-createfromsegment instead, never this skill.
 required_packages:
   com.unity.2d.tilemap: ">=1.0.0"

--- a/skills/tilemap-ruletile-createfromsegment/SKILL.md
+++ b/skills/tilemap-ruletile-createfromsegment/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: tilemap-ruletile-createfromsegment
 description: Use when the user wants tiles that auto-tile (autotile) as they paint, wants a RuleTile built from existing terrain or edge sprites, or asks to make sprites "tile correctly" or "connect properly". Also converts sprite-segment-3x3grid output patterns into Unity RuleTile TilingRules: 3x3 grid text patterns (X, ., *) become TilingRule neighbor configurations, mapping '.' to 'This' rules and 'X' to 'DontCare', sorted by specificity (more 'This' rules first). Use when creating RuleTiles from sprite analysis or defining tile neighbor rules programmatically. Sprites must be provided as input.
 required_packages:
   com.unity.2d.tilemap: ">=1.0.0"

--- a/skills/ui-imgui/SKILL.md
+++ b/skills/ui-imgui/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: ui-imgui
 description: Unity IMGUI (Immediate Mode GUI) expert for legacy editor tools using OnGUI/immediate mode. Generates and modifies IMGUI EditorWindows, custom Inspectors, PropertyDrawers, and scripts with IMGUI code (OnGUI, OnInspectorGUI). Use when maintaining existing IMGUI editor code or when user explicitly requests IMGUI/OnGUI. Do not use for NEW editor windows or tools: new editor UI defaults to UI Toolkit (ui-uitk) unless the project already uses IMGUI exclusively or the user asks for OnGUI by name.
 ---
 

--- a/skills/ui-ugui/SKILL.md
+++ b/skills/ui-ugui/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: ui-ugui
 description: Unity uGUI (Canvas-based) UI expert. Understands, edits, and generates Canvas hierarchies, RectTransforms, Layout Groups, and prefab UI. Use for requests involving Canvas, uGUI, RectTransform, or .prefab UI files.
 ---
 

--- a/skills/ui-uitk/SKILL.md
+++ b/skills/ui-uitk/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: ui-uitk
 description: Unity UI Toolkit expert for Unity 6.0+. Understands, edits, and generates UXML and USS files with flex-based layouts. Use for requests involving .uxml, .uss, UI Toolkit, UIElements, UIDocument, UI runtime binding, Custom UI Elements, Manipulators or PanelSettings.
 ---
 

--- a/skills/ui/SKILL.md
+++ b/skills/ui/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: ui
 description: Unity UI expert for menus, HUDs, screens, panels, buttons, labels, and all visual interface elements. Handles questions about UI in scenes or prefabs (how many elements, what exists, structure analysis), styling changes (colors, borders, backgrounds, fonts, spacing, rounded corners), layout adjustments, and UI generation. Routes to UI Toolkit, uGUI, or IMGUI based on project context. Use for ANY request to build, edit, or understand game UI (menus, HUDs, settings or pause screens) when no framework is named: consult this skill to detect which UI system the project uses before writing any UI code, even for a request that looks simple enough to build directly.
 ---
 

--- a/skills/validate-urp-render-graph-renderer-feature/SKILL.md
+++ b/skills/validate-urp-render-graph-renderer-feature/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: validate-urp-render-graph-renderer-feature
 description: Use when the user wants to review or validate a Unity 6+ URP ScriptableRendererFeature that uses the Render Graph API. Checks for correctness issues - resource wiring, material binding, execution structure, descriptor usage, global resource exposure, and Render Graph best practices.
 ---
 # Skill: Validate a Unity URP Render Graph Renderer Feature


### PR DESCRIPTION
## What

Adds the frontmatter `name:` field to the 18 skills that were missing it. One line per file, 18 files, nothing else touched.

## Why

Every skill in the public `Unity-Technologies/skills` repo carries a frontmatter `name:`. Here, only the 11 skills added in the second wave had it; the 18 from the first wave did not. That single line was the largest source of noise when diffing the two copies of a skill, and it hid the real content differences underneath.

With this applied, the number of skills whose `SKILL.md` is byte-identical between the two repos goes from 7 to 19.

## Behavior

No change. The value is the folder name in all 18 cases, which is what the loader already falls back to when the field is absent, and it matches the public repo's value exactly (verified for all 18). No command name changes.

## How To Test/Validate

The diff is 18 single-line insertions. To confirm the values are right:

```
for d in skills/*/; do
  s=$(basename "$d")
  n=$(sed -n 's/^name: *//p' "$d/SKILL.md" | head -1)
  [ "$n" = "$s" ] || echo "MISMATCH: $s -> $n"
done
```

Prints nothing when every `name:` matches its folder.
