### PR TITLE
fix(unity-package-management): correct the Editor binary path on Linux and Windows

### DIFF
--- a/skills/unity-package-management/SKILL.md
+++ b/skills/unity-package-management/SKILL.md
@@ -229,8 +229,8 @@ case "$(uname)" in
   Darwin) if [ -d "$ED/Unity.app" ]; then UNITY_BIN="$ED/Unity.app/Contents/MacOS/Unity";
           elif [[ "$ED" == *.app ]]; then UNITY_BIN="$ED/Contents/MacOS/Unity";
           else UNITY_BIN="$ED/Unity"; fi ;;
-  Linux)  UNITY_BIN="$ED/Unity" ;;
-  *)      UNITY_BIN="$ED/Unity.exe" ;;   # Windows (Git Bash / MSYS); use Unity.exe in PowerShell
+  Linux)  UNITY_BIN="$ED/Editor/Unity" ;;
+  *)      UNITY_BIN="$ED/Editor/Unity.exe" ;;   # Windows (Git Bash / MSYS); use Editor\Unity.exe in PowerShell
 esac
 
 "$UNITY_BIN" -batchmode -projectPath "$PROJECT" -executeMethod "$METHOD" -logFile -


### PR DESCRIPTION
## What

Corrects the Editor executable path in the headless-install snippet for Linux and Windows.

```diff
-  Linux)  UNITY_BIN="$ED/Unity" ;;
-  *)      UNITY_BIN="$ED/Unity.exe" ;;
+  Linux)  UNITY_BIN="$ED/Editor/Unity" ;;
+  *)      UNITY_BIN="$ED/Editor/Unity.exe" ;;
```

## Why

`$ED` comes from `unity editors path`, which returns the **version directory**. Verified on macOS: `unity editors path 6000.6.0f1` returns `/Applications/Unity/Hub/Editor/6000.6.0f1`, and `Unity.app` sits directly inside it, which is why the macOS branch was already correct.

On Linux and Windows the executable is one level further down, under `Editor/`. The Hub's own layout confirms it, for example `/home/dev/Unity/Hub/Editor/6000.5.2f1/Editor/Unity`. So `$ED/Unity` and `$ED/Unity.exe` resolved to nothing, and the snippet failed for anyone not on macOS.

The copy of this skill in the public `Unity-Technologies/skills` repo already had the correct paths; this brings the two into agreement.

## How To Test/Validate

On Linux or Windows, with an Editor installed through the Hub:

```
ED=$(unity editors path <version> --format json | python3 -c "import sys,json;print(json.load(sys.stdin)['data']['path'])")
ls "$ED/Editor/Unity"      # Linux — exists
ls "$ED/Unity"             # the old path — no such file
```

## Scope

Two lines in one file. No other change.
