### PR TITLE
chore(unity-package-management): soften the claim about `unity run` and -quit

### DIFF
--- a/skills/unity-package-management/SKILL.md
+++ b/skills/unity-package-management/SKILL.md
@@ -42,7 +42,7 @@ back on the Editor's main-loop pump, so a blocking `while (!req.IsCompleted)` bu
 deadlocks it). The Editor must **stay alive** after `-executeMethod` returns, until the request
 finishes.
 
-`unity run` **cannot** be used for the installer: it always injects `-quit` (see the reserved
+`unity run` **cannot** be used for the installer: its default path injects `-quit` (see the reserved
 flags in the **`unity-cli`** skill). With `-quit`, the Editor quits the instant the method
 returns — before UPM resolves — so packages never install and the callback never runs.
 


### PR DESCRIPTION
## What

One line. Changes "it always injects `-quit`" to "its default path injects `-quit`" in the note explaining why `unity run` cannot be used for the headless installer.

## Why

The stronger claim is not one we can support. `unity run --help` does not document the flag either way, and the copy of this skill in the public `Unity-Technologies/skills` repo already carries the narrower wording. Adopting it makes the two copies agree and stops the text over-claiming.

## Scope

One line in one file. The surrounding guidance, which is to use `-executeMethod` directly rather than `unity run`, is unchanged.