### PR TITLE
chore: prepare the Codex manifest for submission

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -8,7 +8,7 @@
       "name": "unity",
       "source": {
         "source": "local",
-        "path": "."
+        "path": "./"
       },
       "policy": {
         "installation": "AVAILABLE",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "unity",
-  "version": "0.1.0-beta",
+  "version": "0.1.3-beta",
   "description": "Unity's official plugin for Codex, with curated skills for game development, monetization, and performance optimization.",
   "author": {
     "name": "Unity Technologies",


### PR DESCRIPTION
## What

Two changes to the Codex-side manifests, ahead of submitting to the Codex directory.

| File | Change |
|---|---|
| `.codex-plugin/plugin.json` | `version` `0.1.0-beta` → `0.1.3-beta` |
| `.agents/plugins/marketplace.json` | `source.path` `"."` → `"./"` |

## Why

**The version was two releases behind.** The Codex manifest still declared `0.1.0-beta`, which is the 18-skill wave-1 release. The repo ships 31 skills now. Submitting as-is would list a version that does not describe what a user gets.

**The source path violated the spec.** The [plugin docs](https://developers.openai.com/plugins/build/plugins) state that every path must start with `./`, and this one was a bare `.`.

## Deliberately not changed

`policy.authentication` is still `ON_INSTALL`. This plugin ships skills only — no MCP server, no API, nothing to authenticate against — so that value looks wrong, and the Claude manifest has no auth field at all. But `policy.authentication` is a **required** field and `ON_INSTALL` is the only value the published spec names; it documents the field as "decide whether auth happens on install or first use" without enumerating the values or covering the no-auth case. Guessing at an enum in a submission manifest is worse than leaving the one documented value, so this needs an answer from the Codex side first.

The same applies to `interface.capabilities`, currently `["Interactive", "Read", "Write"]`. The spec shows `["Read", "Write"]` as an example and never enumerates the allowed values, so whether `Interactive` is valid — and whether we should be declaring something for the skills that run shell commands — is also worth confirming rather than guessing.

## Checked and fine

- `screenshots: []` — the field is optional, so an empty array is not a submission blocker.
- Both asset paths resolve: `assets/unity.svg` (2,456 bytes) and `assets/unity-small.svg` (2,227 bytes).
- All three declared URLs return 200: the homepage, the privacy policy, and the terms of service.
- `skills: "./skills/"` matches the documented form.

## Note on version drift

`.claude-plugin/plugin.json` stays at `0.1.2-beta` on purpose; its next bump goes with [#31](https://github.com/Unity-Technologies/unity-agent-plugin/pull/31). So the two manifests describe the same skill set under different version numbers until then.
