### PR TITLE
fix: declare ON_USE rather than ON_INSTALL for the Codex plugin policy

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -12,7 +12,7 @@
       },
       "policy": {
         "installation": "AVAILABLE",
-        "authentication": "ON_INSTALL"
+        "authentication": "ON_USE"
       },
       "category": "Developer Tools"
     }


### PR DESCRIPTION
## What

One line in `.agents/plugins/marketplace.json`:

```diff
-"authentication": "ON_INSTALL"
+"authentication": "ON_USE"
```

## Why

This plugin ships skills only. No MCP server, no API, nothing to sign in to. `ON_INSTALL` is what a service connector declares, and it risks Codex asking users for credentials we never take.

Both values are in production use, so this is not a spec question but a semantic one, and the closest analogues settle it. OpenAI's own skills-only local plugins all declare `ON_USE`: `documents`, `pdf`, `spreadsheets`, `presentations`, `template-creator`. `ON_INSTALL` is what `github`, `slack`, `stripe`, `notion` and `figma` declare. Across the plugins visible in a local Codex install, 21 declare `ON_USE` and none of them connect to an external service the way ours does not.

The published spec names only `ON_INSTALL` and does not cover the no-auth case, which is why this was left alone in #37 pending evidence rather than guessed at.

## Scope

One line. Nothing else in the manifest changes.