### PR TITLE
chore: bump the Codex manifest to 0.1.4-beta

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "unity",
-  "version": "0.1.3-beta",
+  "version": "0.1.4-beta",
   "description": "Unity's official plugin for Codex, with curated skills for game development, monetization, and performance optimization.",
   "author": {
     "name": "Unity Technologies",


### PR DESCRIPTION
## What

`.codex-plugin/plugin.json` version `0.1.3-beta` → `0.1.4-beta`. One line.

## Why

Cuts a release for resubmission to the Codex directory. Since `0.1.3-beta` was submitted, [#39](https://github.com/Unity-Technologies/unity-agent-plugin/pull/39) and [#40](https://github.com/Unity-Technologies/unity-agent-plugin/pull/40) landed, both correcting the composer icon's declared dimensions.

The listing's light-mode and dark-mode icons are uploaded through the OpenAI dashboard rather than carried in the repo, so `assets/` is unchanged by this.

## Note

`.claude-plugin/plugin.json` stays at `0.1.2-beta`. The two manifests describe the same 31 skills under different version numbers until the Claude side is bumped.