### PR TITLE
chore: bump the Codex manifest to 0.1.5-beta

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "unity",
-  "version": "0.1.4-beta",
+  "version": "0.1.5-beta",
   "description": "Unity's official plugin for Codex, with curated skills for game development, monetization, and performance optimization.",
   "author": {
     "name": "Unity Technologies",


### PR DESCRIPTION
Bump `.codex-plugin/plugin.json` to 0.1.5-beta for the next Codex directory submission. The zip built from this commit carries the refreshed `unity-cli` skill (#47) and the README update (#45).