### PR TITLE
chore: mark the Codex plugin as desktop-only

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -23,6 +23,7 @@
     "shader-graph"
   ],
   "skills": "./skills/",
+  "requires_local_executor": true,
   "interface": {
     "displayName": "Unity",
     "shortDescription": "Build, monetize, tune games",


### PR DESCRIPTION
Add `"requires_local_executor": true` at the root of `.codex-plugin/plugin.json` so the Codex plugin directory shows the Desktop only badge. The plugin drives a local Unity project and Editor, so it is not usable on mobile.