### PR TITLE
chore: bump the Codex manifest to 0.1.6-beta

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "unity",
-  "version": "0.1.5-beta",
+  "version": "0.1.6-beta",
   "description": "Unity's official plugin for Codex, with curated skills for game development, monetization, and performance optimization.",
   "author": {
     "name": "Unity Technologies",


### PR DESCRIPTION
Bump `.codex-plugin/plugin.json` to 0.1.6-beta for the next Codex directory submission, which will carry the desktop-only badge (#49).